### PR TITLE
fix: update 'Look Up Event' button in Calendar

### DIFF
--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/CalendarScreenTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/CalendarScreenTest.kt
@@ -2,6 +2,7 @@ package com.github.lookupgroup27.lookup.ui.overview
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.github.lookupgroup27.lookup.model.calendar.CalendarViewModel
@@ -74,7 +75,7 @@ class CalendarScreenTest {
 
   @Test
   fun testLookUpEventButtonExists() {
-    composeTestRule.onNodeWithText("Look Up Event").assertIsDisplayed()
+    composeTestRule.onNodeWithContentDescription("Look Up Event").assertIsDisplayed()
   }
 
   // Add more tests when figma is updated with all the components and testTags

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Calendar.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Calendar.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.lazy.*
 import androidx.compose.foundation.lazy.grid.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.*
@@ -40,7 +42,14 @@ fun CalendarScreen(
 
     Spacer(modifier = Modifier.height(16.dp))
 
-    Button(onClick = { showDialog = true }) { Text("Look Up Event") }
+      Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.End
+      ) {
+          IconButton(onClick = { showDialog = true }) {
+              Icon(imageVector = Icons.Default.Search, contentDescription = "Look Up Event")
+          }
+      }
 
     Spacer(modifier = Modifier.height(16.dp))
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Calendar.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Calendar.kt
@@ -42,14 +42,11 @@ fun CalendarScreen(
 
     Spacer(modifier = Modifier.height(16.dp))
 
-      Row(
-          modifier = Modifier.fillMaxWidth(),
-          horizontalArrangement = Arrangement.End
-      ) {
-          IconButton(onClick = { showDialog = true }) {
-              Icon(imageVector = Icons.Default.Search, contentDescription = "Look Up Event")
-          }
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+      IconButton(onClick = { showDialog = true }) {
+        Icon(imageVector = Icons.Default.Search, contentDescription = "Look Up Event")
       }
+    }
 
     Spacer(modifier = Modifier.height(16.dp))
 


### PR DESCRIPTION
## Description
This PR updates the "Look Up Event" button by replacing the text with a magnifying glass icon and moving it to the right for better UI clarity. The functionality remains unchanged.
