### PR TITLE
Rename Test Files and Classes, and Move `MapKtTest.kt` to Correct Package

### DIFF
--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/authentication/SignInKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/authentication/SignInKtTest.kt
@@ -20,7 +20,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class LoginTest : TestCase() {
+class SignInKtTest : TestCase() {
 
   @get:Rule val composeTestRule = createComposeRule()
 

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/map/MapKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/map/MapKtTest.kt
@@ -1,13 +1,12 @@
-package com.github.lookupgroup27.lookup.ui.overview
+package com.github.lookupgroup27.lookup.ui.map
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
-import com.github.lookupgroup27.lookup.ui.map.MapScreen
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
 import org.junit.*
 import org.mockito.kotlin.*
 
-class MapScreenTest {
+class MapKtTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/CalendarKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/CalendarKtTest.kt
@@ -13,7 +13,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-class CalendarScreenTest {
+class CalendarKtTest {
 
   private lateinit var calendarViewModel: CalendarViewModel
   private lateinit var navigationActions: NavigationActions

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/LandingKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/LandingKtTest.kt
@@ -17,7 +17,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class LandingScreenTest {
+class LandingKtTest {
 
   @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
 

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/MenuKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/MenuKtTest.kt
@@ -6,7 +6,7 @@ import com.github.lookupgroup27.lookup.ui.navigation.*
 import org.junit.*
 import org.mockito.kotlin.*
 
-class MenuScreenTest {
+class MenuKtTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/QuizKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/QuizKtTest.kt
@@ -1,4 +1,4 @@
-package com.github.lookupgroup27.lookup.ui.skytracker
+package com.github.lookupgroup27.lookup.ui.overview
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -11,26 +11,26 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
-class SkyTrackerScreenTest {
+class QuizKtTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
   private val mockNavigationActions: NavigationActions = mock()
 
   @Test
-  fun skyTrackerScreen_displaysSkyTrackerText() {
-    composeTestRule.setContent { SkyTrackerScreen(navigationActions = mockNavigationActions) }
+  fun quizScreen_displaysQuizText() {
+    composeTestRule.setContent { QuizScreen(navigationActions = mockNavigationActions) }
 
-    // Verify that the "Sky Tracker Screen" text is displayed
-    composeTestRule.onNodeWithText("Sky Tracker Screen").assertIsDisplayed()
+    // Verify that the "Quiz Screen" text is displayed
+    composeTestRule.onNodeWithText("Quiz Screen").assertIsDisplayed()
   }
 
   @Test
-  fun skyTrackerScreen_clickBackButton_navigatesBack() {
-    composeTestRule.setContent { SkyTrackerScreen(navigationActions = mockNavigationActions) }
+  fun quizScreen_clickBackButton_navigatesBack() {
+    composeTestRule.setContent { QuizScreen(navigationActions = mockNavigationActions) }
 
     // Perform click on the back button
-    composeTestRule.onNodeWithTag("go_back_button_skyTracker").performClick()
+    composeTestRule.onNodeWithTag("go_back_button_quiz").performClick()
 
     // Verify navigation back action is triggered
     verify(mockNavigationActions).goBack()

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/profile/ProfileKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/profile/ProfileKtTest.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
-class ProfileScreenTest {
+class ProfileKtTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/skytracker/SkyTrackerKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/skytracker/SkyTrackerKtTest.kt
@@ -1,4 +1,4 @@
-package com.github.lookupgroup27.lookup.ui.overview
+package com.github.lookupgroup27.lookup.ui.skytracker
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -11,26 +11,26 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
-class QuizScreenTest {
+class SkyTrackerKtTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
   private val mockNavigationActions: NavigationActions = mock()
 
   @Test
-  fun quizScreen_displaysQuizText() {
-    composeTestRule.setContent { QuizScreen(navigationActions = mockNavigationActions) }
+  fun skyTrackerScreen_displaysSkyTrackerText() {
+    composeTestRule.setContent { SkyTrackerScreen(navigationActions = mockNavigationActions) }
 
-    // Verify that the "Quiz Screen" text is displayed
-    composeTestRule.onNodeWithText("Quiz Screen").assertIsDisplayed()
+    // Verify that the "Sky Tracker Screen" text is displayed
+    composeTestRule.onNodeWithText("Sky Tracker Screen").assertIsDisplayed()
   }
 
   @Test
-  fun quizScreen_clickBackButton_navigatesBack() {
-    composeTestRule.setContent { QuizScreen(navigationActions = mockNavigationActions) }
+  fun skyTrackerScreen_clickBackButton_navigatesBack() {
+    composeTestRule.setContent { SkyTrackerScreen(navigationActions = mockNavigationActions) }
 
     // Perform click on the back button
-    composeTestRule.onNodeWithTag("go_back_button_quiz").performClick()
+    composeTestRule.onNodeWithTag("go_back_button_skyTracker").performClick()
 
     // Verify navigation back action is triggered
     verify(mockNavigationActions).goBack()


### PR DESCRIPTION
# Rename Test Files and Classes, and Move `MapKtTest.kt` to Correct Package

### Description
This PR addresses the following changes to improve the structure and naming consistency of test files:

1. **Renamed Test Files and Classes**:
   - Renamed several test files and their corresponding classes to ensure they follow proper naming conventions and are correctly linked in Android Studio.
   - This helps in better test discovery and avoids potential issues with mismatches between file names and class names.

2. **Moved `MapKtTest.kt` to the Correct Package**:
   - The `MapKtTest.kt` file was located in the wrong package. It has been moved to its correct package to match the structure of the source code and ensure tests run properly in the correct context.

### Changes Made:
- **File Renames**:
  - `LoginTest.kt` → `SignInKtTest.kt`
  - `MapScreenTest.kt` → `MapKtTest.kt`
  - `CalendarScreenTest.kt` → `CalendarKtTest.kt`
  - `LandingScreenTest.kt` → `LandingKtTest.kt`
  - `MenuScreenTest.kt` → `MenuKtTest.kt`
  - `QuizScreenTest.kt` → `QuizKtTest.kt`
  - `ProfileScreenTest.kt` → `ProfileKtTest.kt`
  - `SkyTrackerScreen.kt` → `SkyTrackerKtTest.kt`

- **Moved File**:
  - `com/github/lookupgroup27/lookup/ui/overview/MapKtTest.kt` -> `com/github/lookupgroup27/lookup/ui/map/MapKtTest.kt`
