### PR TITLE
feature: delete profile

### DIFF
--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/profile/ProfileInformationKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/profile/ProfileInformationKtTest.kt
@@ -70,38 +70,6 @@ class ProfileInformationScreenTest {
   }
 
   @Test
-  fun saveButtonDisabledWhenAnyFieldIsEmpty() {
-    composeTestRule.setContent { ProfileInformationScreen(profileViewModel, navigationActions) }
-
-    // Initially, all fields are empty, so the save button should be disabled
-    composeTestRule.onNodeWithTag("profileSaveButton").assertIsNotEnabled()
-
-    // Fill only the username, leave other fields empty
-    composeTestRule.onNodeWithTag("editProfileUsername").performTextInput("JohnDoe")
-    composeTestRule.onNodeWithTag("profileSaveButton").assertIsNotEnabled()
-
-    // Fill in the email and leave the bio empty
-    composeTestRule.onNodeWithTag("editProfileEmail").performTextInput("john.doe@example.com")
-    composeTestRule.onNodeWithTag("profileSaveButton").assertIsNotEnabled()
-
-    // Now fill the bio
-    composeTestRule.onNodeWithTag("editProfileBio").performTextInput("This is a bio")
-
-    // Now all fields are filled, the save button should be enabled
-    composeTestRule.onNodeWithTag("profileSaveButton").assertIsEnabled()
-  }
-
-  @Test
-  fun saveButtonWorks() {
-    composeTestRule.setContent { ProfileInformationScreen(profileViewModel, navigationActions) }
-
-    // Perform click on the save button
-    composeTestRule.onNodeWithTag("profileSaveButton").performClick()
-
-    // Mock behavior can be asserted in ViewModel (not shown here, as it's logic dependent)
-  }
-
-  @Test
   fun logoutButtonWorks() {
     composeTestRule.setContent { ProfileInformationScreen(profileViewModel, navigationActions) }
 
@@ -113,7 +81,7 @@ class ProfileInformationScreenTest {
   }
 
   @Test
-  fun saveButtonDisabledWhenFieldsAreIncomplete() {
+  fun saveButtonWorks() {
     composeTestRule.setContent { ProfileInformationScreen(profileViewModel, navigationActions) }
 
     // Assert: Save button is initially disabled
@@ -133,6 +101,8 @@ class ProfileInformationScreenTest {
     composeTestRule.onNodeWithTag("editProfileBio").performTextInput("This is a bio")
     // Assert: Save button should now be enabled
     composeTestRule.onNodeWithTag("profileSaveButton").assertIsEnabled()
+    composeTestRule.onNodeWithTag("profileSaveButton").performClick()
+    verify(navigationActions).navigateTo(Screen.PROFILE)
   }
 
   @Test
@@ -155,7 +125,27 @@ class ProfileInformationScreenTest {
   fun deleteButtonWorks() {
     composeTestRule.setContent { ProfileInformationScreen(profileViewModel, navigationActions) }
 
+    // Assert: Save button is initially disabled
+    composeTestRule.onNodeWithTag("profileSaveButton").assertIsNotEnabled()
+
+    // Act: Fill in only the username
+    composeTestRule.onNodeWithTag("editProfileUsername").performTextInput("JohnDoe")
+    // Assert: Save button is still disabled
+    composeTestRule.onNodeWithTag("profileSaveButton").assertIsNotEnabled()
+
+    // Act: Fill in email
+    composeTestRule.onNodeWithTag("editProfileEmail").performTextInput("john.doe@example.com")
+    // Assert: Save button is still disabled because bio is empty
+    composeTestRule.onNodeWithTag("profileSaveButton").assertIsNotEnabled()
+
+    // Act: Fill in the bio
+    composeTestRule.onNodeWithTag("editProfileBio").performTextInput("This is a bio")
+    composeTestRule.onNodeWithTag("profileSaveButton").performClick()
+    verify(navigationActions).navigateTo(Screen.PROFILE)
+    // Assert: Save button should now be enabled
+    composeTestRule.onNodeWithTag("profileDelete").assertIsEnabled()
     // Scroll to the delete button if it's off-screen, then click it
     composeTestRule.onNodeWithTag("profileDelete").performScrollTo().performClick()
+    verify(navigationActions).navigateTo(Screen.MENU)
   }
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/profile/ProfileInformationKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/profile/ProfileInformationKtTest.kt
@@ -1,26 +1,12 @@
 package com.github.lookupgroup27.lookup.ui.profile
 
-import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
-import androidx.compose.ui.test.performTextInput
-import com.github.lookupgroup27.lookup.model.profile.ProfileRepository
-import com.github.lookupgroup27.lookup.model.profile.ProfileViewModel
-import com.github.lookupgroup27.lookup.model.profile.UserProfile
-import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
-import com.github.lookupgroup27.lookup.ui.navigation.Screen
+import com.github.lookupgroup27.lookup.model.profile.*
+import com.github.lookupgroup27.lookup.ui.navigation.*
 import com.google.firebase.auth.FirebaseAuth
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.mockito.Mockito
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
+import org.junit.*
+import org.mockito.Mockito.*
 
 class ProfileInformationScreenTest {
 
@@ -30,9 +16,6 @@ class ProfileInformationScreenTest {
   private lateinit var firebaseAuth: FirebaseAuth
 
   @get:Rule val composeTestRule = createComposeRule()
-
-  private val mockUserProfile =
-      UserProfile(username = "JohnDoe", bio = "This is a bio", email = "john.doe@example.com")
 
   @Before
   fun setUp() {
@@ -126,7 +109,7 @@ class ProfileInformationScreenTest {
     composeTestRule.onNodeWithTag("profileLogout").performScrollTo().performClick()
 
     // Verify that the navigation action to the landing screen was triggered
-    Mockito.verify(navigationActions).navigateTo(Screen.LANDING)
+    verify(navigationActions).navigateTo(Screen.LANDING)
   }
 
   @Test
@@ -158,5 +141,21 @@ class ProfileInformationScreenTest {
 
     // Assert: Save button is disabled because no fields have been populated
     composeTestRule.onNodeWithTag("profileSaveButton").assertIsNotEnabled()
+  }
+
+  @Test
+  fun deleteButtonDisabledWhenProfileIsNull() {
+    composeTestRule.setContent { ProfileInformationScreen(profileViewModel, navigationActions) }
+
+    // Assert: Delete button is disabled because the profile is null
+    composeTestRule.onNodeWithTag("profileDelete").assertIsNotEnabled()
+  }
+
+  @Test
+  fun deleteButtonWorks() {
+    composeTestRule.setContent { ProfileInformationScreen(profileViewModel, navigationActions) }
+
+    // Scroll to the delete button if it's off-screen, then click it
+    composeTestRule.onNodeWithTag("profileDelete").performScrollTo().performClick()
   }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/profile/ProfileRepository.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/profile/ProfileRepository.kt
@@ -7,5 +7,7 @@ interface ProfileRepository {
 
   fun updateUserProfile(profile: UserProfile, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
+  fun deleteUserProfile(profile: UserProfile, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+
   fun logoutUser()
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/profile/ProfileRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/profile/ProfileRepositoryFirestore.kt
@@ -3,7 +3,6 @@ package com.github.lookupgroup27.lookup.model.profile
 import android.util.Log
 import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.auth
 import com.google.firebase.firestore.FirebaseFirestore
 
 data class UserProfile(val username: String = " ", val email: String = " ", val bio: String = " ")
@@ -52,6 +51,19 @@ class ProfileRepositoryFirestore(
     val userId = auth.currentUser?.uid
     if (userId != null) {
       performFirestoreOperation(usersCollection.document(userId).set(profile), onSuccess, onFailure)
+    } else {
+      onFailure(Exception("User not logged in"))
+    }
+  }
+
+  override fun deleteUserProfile(
+      profile: UserProfile,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    val userId = auth.currentUser?.uid
+    if (userId != null) {
+      performFirestoreOperation(usersCollection.document(userId).delete(), onSuccess, onFailure)
     } else {
       onFailure(Exception("User not logged in"))
     }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/profile/ProfileViewModel.kt
@@ -1,14 +1,10 @@
 package com.github.lookupgroup27.lookup.model.profile
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.*
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.firestore
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 class ProfileViewModel(private val repository: ProfileRepository) : ViewModel() {
@@ -44,6 +40,18 @@ class ProfileViewModel(private val repository: ProfileRepository) : ViewModel() 
           onFailure = { exception ->
             _profileUpdateStatus.value = false
             _error.value = "Failed to update profile: ${exception.message}"
+          })
+    }
+  }
+
+  fun deleteUserProfile(profile: UserProfile) {
+    viewModelScope.launch {
+      repository.deleteUserProfile(
+          profile,
+          onSuccess = { _profileUpdateStatus.value = true },
+          onFailure = { exception ->
+            _profileUpdateStatus.value = false
+            _error.value = "Failed to delete profile: ${exception.message}"
           })
     }
   }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/ProfileInformation.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/ProfileInformation.kt
@@ -1,41 +1,19 @@
 package com.github.lookupgroup27.lookup.ui.profile
 
 import android.annotation.SuppressLint
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.*
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.*
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import com.github.lookupgroup27.lookup.model.profile.ProfileViewModel
-import com.github.lookupgroup27.lookup.model.profile.UserProfile
-import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
-import com.github.lookupgroup27.lookup.ui.navigation.Screen
+import com.github.lookupgroup27.lookup.model.profile.*
+import com.github.lookupgroup27.lookup.ui.navigation.*
 import com.google.firebase.auth.FirebaseAuth
 
 @SuppressLint("StateFlowValueCalledInComposition")
@@ -54,7 +32,6 @@ fun ProfileInformationScreen(
   var username by remember { mutableStateOf(profile?.username ?: "") }
   var bio by remember { mutableStateOf(profile?.bio ?: "") }
   var email by remember { mutableStateOf(userEmail) }
-  val context = LocalContext.current
 
   Column(
       verticalArrangement = Arrangement.Top,
@@ -126,13 +103,9 @@ fun ProfileInformationScreen(
 
               Button(
                   onClick = {
-                    var newProfile: UserProfile
-                    if (profile != null) {
-                      newProfile = profile.copy(username = username, bio = bio, email = email)
-                    } else {
-                      newProfile = UserProfile(username = username, bio = bio, email = email)
-                    }
-
+                    val newProfile: UserProfile =
+                        profile?.copy(username = username, bio = bio, email = email)
+                            ?: UserProfile(username = username, bio = bio, email = email)
                     profileViewModel.updateUserProfile(newProfile)
                   },
                   enabled = username.isNotEmpty() && bio.isNotEmpty() && email.isNotEmpty(),
@@ -151,6 +124,17 @@ fun ProfileInformationScreen(
                   colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF410002)),
                   modifier = Modifier.width(131.dp).height(40.dp).testTag("profileLogout")) {
                     Text(text = "Sign out", color = Color.White)
+                  }
+              Spacer(modifier = Modifier.height(30.dp))
+              Button(
+                  onClick = {
+                    profileViewModel.deleteUserProfile(profile!!)
+                    navigationActions.navigateTo(Screen.MENU)
+                  },
+                  enabled = username.isNotEmpty() && bio.isNotEmpty() && email.isNotEmpty(),
+                  colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF410002)),
+                  modifier = Modifier.width(131.dp).height(40.dp).testTag("profileDelete")) {
+                    Text(text = "Delete", color = Color.White)
                   }
             }
       }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/ProfileInformation.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/ProfileInformation.kt
@@ -107,6 +107,7 @@ fun ProfileInformationScreen(
                         profile?.copy(username = username, bio = bio, email = email)
                             ?: UserProfile(username = username, bio = bio, email = email)
                     profileViewModel.updateUserProfile(newProfile)
+                    navigationActions.navigateTo(Screen.PROFILE)
                   },
                   enabled = username.isNotEmpty() && bio.isNotEmpty() && email.isNotEmpty(),
                   colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF30315B)),
@@ -128,7 +129,10 @@ fun ProfileInformationScreen(
               Spacer(modifier = Modifier.height(30.dp))
               Button(
                   onClick = {
-                    profileViewModel.deleteUserProfile(profile!!)
+                    profile?.let {
+                      profileViewModel.deleteUserProfile(it)
+                      profileViewModel.logoutUser()
+                    }
                     navigationActions.navigateTo(Screen.MENU)
                   },
                   enabled = username.isNotEmpty() && bio.isNotEmpty() && email.isNotEmpty(),

--- a/app/src/test/java/com/github/lookupgroup27/lookup/model/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/model/profile/ProfileViewModelTest.kt
@@ -117,4 +117,36 @@ class ProfileViewModelTest {
     assertFalse(viewModel.profileUpdateStatus.value!!)
     assertEquals("Failed to update profile: Update failed", viewModel.error.value)
   }
+
+  @Test
+  fun `deleteUserProfile calls deleteUserProfile in repository on success`() = runTest {
+    // Simulate successful deletion behavior
+    `when`(repository.deleteUserProfile(any(), any(), any())).thenAnswer { invocation ->
+      val onSuccess = invocation.arguments[1] as () -> Unit
+      onSuccess()
+    }
+
+    viewModel.deleteUserProfile(testProfile)
+
+    // Verifying that the method is indeed called
+    verify(repository).deleteUserProfile(eq(testProfile), any(), any())
+    assertEquals(true, viewModel.profileUpdateStatus.value) // Check if status is set to true
+  }
+
+  @Test
+  fun `deleteUserProfile sets profileUpdateStatus to false and error on failure`() = runTest {
+    // Mock an error scenario in the repository
+    val exception = Exception("Delete failed")
+    `when`(repository.deleteUserProfile(any(), any(), any())).thenAnswer {
+      val onFailure = it.getArgument<(Exception) -> Unit>(2)
+      onFailure(exception)
+    }
+
+    // Call the method
+    viewModel.deleteUserProfile(testProfile)
+
+    // Assert that _profileUpdateStatus is false and _error is set
+    assertFalse(viewModel.profileUpdateStatus.value!!)
+    assertEquals("Failed to delete profile: Delete failed", viewModel.error.value)
+  }
 }


### PR DESCRIPTION
This pull request introduces the functionality to delete a user’s profile from Firestore. The new `deleteUserProfile` method in `ProfileRepositoryFirestore` enables this capability, allowing authenticated users to remove their stored profile data.

**Changes :**
- Added `deleteUserProfile` method to `ProfileRepositoryFirestore`.
- Updated test suite with:
  - Success scenario for profile deletion.
  - Failure scenario where deletion encounters an error.
  - Verification that deletion does not proceed if no user is logged in.

**Related Issues :**
Closes issue #85 