### PR TITLE
Fixes Flickering Effect on Active Screen Navigation Button

### DIFF
--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/feed/FeedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/feed/FeedScreenTest.kt
@@ -20,6 +20,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.never
 
 @RunWith(AndroidJUnit4::class)
 class FeedScreenTest {
@@ -75,7 +76,7 @@ class FeedScreenTest {
     composeTestRule.onNodeWithText("Feed").performClick()
 
     val feedDestination = LIST_TOP_LEVEL_DESTINATION.first { it.textId == "Feed" }
-    Mockito.verify(mockNavigationActions).navigateTo(feedDestination)
+    Mockito.verify(mockNavigationActions, never()).navigateTo(feedDestination)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/map/MapKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/map/MapKtTest.kt
@@ -43,7 +43,7 @@ class MapKtTest {
   }
 
   @Test
-  fun menuScreen_bottomNavigation_clickMapTab_navigatesToMap() {
+  fun mapScreen_bottomNavigation_clickMapTab_doesNotNavigateToMap() {
     composeTestRule.setContent { MapScreen(navigationActions = mockNavigationActions) }
 
     // Click on the Map tab
@@ -51,7 +51,7 @@ class MapKtTest {
 
     val mapDestination = LIST_TOP_LEVEL_DESTINATION.first { it.textId == "Map" }
 
-    // Verify that navigation to the Map screen is triggered with the correct object
-    verify(mockNavigationActions).navigateTo(mapDestination)
+    // Verify that navigation to the Map screen is not triggered
+    verify(mockNavigationActions, never()).navigateTo(mapDestination)
   }
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/MenuKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/MenuKtTest.kt
@@ -32,7 +32,7 @@ class MenuKtTest {
     val menuDestination = LIST_TOP_LEVEL_DESTINATION.first { it.textId == "Menu" }
 
     // Verify that navigation to the Map screen is triggered with the correct object
-    verify(mockNavigationActions).navigateTo(menuDestination)
+    verify(mockNavigationActions, never()).navigateTo(menuDestination)
   }
 
   @Test

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/BottomNavigationMenu.kt
@@ -29,7 +29,7 @@ fun BottomNavigationMenu(
               icon = { Icon(tab.icon, contentDescription = null, tint = Color.White) },
               label = { Text(text = tab.textId, color = Color.White) },
               selected = tab.route == selectedItem,
-              onClick = { onTabSelect(tab) },
+              onClick = { if (selectedItem != tab.route) onTabSelect(tab) },
               modifier = Modifier.clip(shape = RoundedCornerShape(50.dp)).testTag(tab.textId))
         }
       },

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/NavigationActions.kt
@@ -104,7 +104,7 @@ open class NavigationActions(
   /**
    * Navigate to the ImageReview screen with a specific imageUri.
    *
-   * @param imageUri The URI of the captured image to review.
+   * @param encodeImageUri The URI of the captured image to review.
    */
   open fun navigateToImageReview(encodeImageUri: String) {
     navController.navigate("${Route.IMAGE_REVIEW}/$encodeImageUri")


### PR DESCRIPTION
### Fixes Flickering Effect on Active Screen Navigation Button

**Issue**: This PR addresses the issue where the app screen briefly flickers when a user clicks the navigation button for the currently active screen, as described in https://github.com/LookUpGroup27/LookUp/issues/103.

---

### Description

This PR resolves the flickering effect observed when clicking the navigation bar button for an already active screen. This fix enhances user experience by removing unnecessary visual distractions and ensuring stable navigation behavior.

---

### Scope of Changes
- Added a check that you don't ask to navigate to the current screen in `BottomNavigationMenu.kt`

---

### Testing
- Manually tested to confirm the flickering issue is resolved when clicking the active screen’s button.
- Verified that other navigation bar buttons function as expected without any flicker or unintended effects.
