### PR TITLE
fix: cast safely fields in getPosts method

### DIFF
--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/post/PostsRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/post/PostsRepositoryFirestore.kt
@@ -39,9 +39,9 @@ class PostsRepositoryFirestore(private val db: FirebaseFirestore) : PostsReposit
                       data["uid"] as String,
                       data["uri"] as String,
                       data["username"] as String,
-                      data["likes"] as Int,
-                      data["latitude"] as Double,
-                      data["longitude"] as Double,
+                      (data["likes"] as? Long)?.toInt() ?: 0,
+                      (data["latitude"] as? Long)?.toDouble() ?: 0.0,
+                      (data["longitude"] as? Long)?.toDouble() ?: 0.0,
                   )
                 }
                 .filterNotNull()

--- a/app/src/test/java/com/github/lookupgroup27/lookup/model/post/PostsRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/model/post/PostsRepositoryFirestoreTest.kt
@@ -98,7 +98,7 @@ class PostsRepositoryFirestoreTest {
             "uid" to "1",
             "uri" to "uri",
             "username" to "user",
-            "likes" to 10,
+            "likes" to 10L,
             "latitude" to 0.0,
             "longitude" to 0.0)
 


### PR DESCRIPTION
- Updated "likes" field to safely cast from Long to Int
- Updated "latitude" and "longitude" fields to safely cast from Long to Double
- Ensures compatibility with Firebase data types, preventing runtime casting errors
- Adjusted tests to reflect these changes, ensuring mocked data uses safe casting to prevent runtime errors with Firestore data types

Closes issue #114 