### PR TITLE
feat: add picture markers on map

### DIFF
--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/image/ImagePreviewDialogTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/image/ImagePreviewDialogTest.kt
@@ -1,0 +1,48 @@
+package com.github.lookupgroup27.lookup.ui.image
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Rule
+import org.junit.Test
+
+class ImagePreviewDialogTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun imagePreviewDialogDisplaysWithValidUri() {
+    // Set up a fake image URI
+    val fakeUri = "https://via.placeholder.com/150"
+    val fakeUsername = "User1"
+
+    // Set the Compose content to ImagePreviewDialog
+    composeTestRule.setContent {
+      ImagePreviewDialog(uri = fakeUri, username = fakeUsername, onDismiss = {})
+    }
+
+    // Verify that the dialog is displayed
+    composeTestRule.onNodeWithTag("imagePreviewDialog").assertIsDisplayed()
+    // Verify that the username is displayed
+    composeTestRule.onNodeWithText("Posted by: $fakeUsername").assertIsDisplayed()
+  }
+
+  @Test
+  fun imagePreviewDialogCloseButtonWorks() {
+    val fakeUri = "https://via.placeholder.com/150"
+    var dialogDismissed = false
+
+    // Set the Compose content to ImagePreviewDialog
+    composeTestRule.setContent {
+      ImagePreviewDialog(uri = fakeUri, username = "User1", onDismiss = { dialogDismissed = true })
+    }
+
+    // Perform click on the "Close" button
+    composeTestRule.onNodeWithText("Close").performClick()
+
+    // Verify that the dialog was dismissed
+    assert(dialogDismissed)
+  }
+}

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/image/ImageReviewKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/image/ImageReviewKtTest.kt
@@ -91,25 +91,4 @@ class ImageReviewTest {
     composeTestRule.onNodeWithText("No image available").assertIsDisplayed()
   }
 
-  @Test
-  fun testSaveImageButtonTriggersUpload() {
-    val imageFile = File("path/to/image")
-    composeTestRule.setContent {
-      ImageReviewScreen(
-          navigationActions = mockNavigationActions, imageFile = imageFile, postsViewModel)
-    }
-    composeTestRule.onNodeWithTag("confirm_button").performClick()
-  }
-
-  @Test
-  fun testDiscardImageButton() {
-    composeTestRule.setContent {
-      ImageReviewScreen(
-          navigationActions = mockNavigationActions,
-          imageFile = File("path/to/image"),
-          postsViewModel)
-    }
-    composeTestRule.onNodeWithTag("cancel_button").performClick()
-    verify(mockNavigationActions).navigateTo(Screen.TAKE_IMAGE)
-  }
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/image/ImageReviewKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/image/ImageReviewKtTest.kt
@@ -73,15 +73,12 @@ class ImageReviewTest {
     verify(mockNavigationActions).navigateTo(Screen.TAKE_IMAGE)
   }
 
-
   @Test
   fun testImageDisplayedWhenImageFileIsNotNull() {
     val imageFile = File("path/to/image")
     composeTestRule.setContent {
       ImageReviewScreen(
-        navigationActions = mockNavigationActions,
-        imageFile = imageFile, postsViewModel
-      )
+          navigationActions = mockNavigationActions, imageFile = imageFile, postsViewModel)
     }
     composeTestRule.onNodeWithContentDescription("Captured Image").assertIsDisplayed()
   }
@@ -89,39 +86,30 @@ class ImageReviewTest {
   @Test
   fun testNoImageAvailableTextWhenImageFileIsNull() {
     composeTestRule.setContent {
-      ImageReviewScreen(
-        navigationActions = mockNavigationActions,
-        imageFile = null, postsViewModel
-      )
+      ImageReviewScreen(navigationActions = mockNavigationActions, imageFile = null, postsViewModel)
     }
     composeTestRule.onNodeWithText("No image available").assertIsDisplayed()
   }
-
 
   @Test
   fun testSaveImageButtonTriggersUpload() {
     val imageFile = File("path/to/image")
     composeTestRule.setContent {
       ImageReviewScreen(
-        navigationActions = mockNavigationActions,
-        imageFile = imageFile, postsViewModel
-      )
+          navigationActions = mockNavigationActions, imageFile = imageFile, postsViewModel)
     }
     composeTestRule.onNodeWithTag("confirm_button").performClick()
-    }
+  }
 
   @Test
   fun testDiscardImageButton() {
     composeTestRule.setContent {
       ImageReviewScreen(
-        navigationActions = mockNavigationActions,
-        imageFile = File("path/to/image"), postsViewModel
-      )
+          navigationActions = mockNavigationActions,
+          imageFile = File("path/to/image"),
+          postsViewModel)
     }
     composeTestRule.onNodeWithTag("cancel_button").performClick()
     verify(mockNavigationActions).navigateTo(Screen.TAKE_IMAGE)
-
-
   }
-
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/image/ImageReviewKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/image/ImageReviewKtTest.kt
@@ -2,7 +2,9 @@ package com.github.lookupgroup27.lookup.ui.image
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.lookupgroup27.lookup.model.post.PostsRepository
@@ -71,18 +73,55 @@ class ImageReviewTest {
     verify(mockNavigationActions).navigateTo(Screen.TAKE_IMAGE)
   }
 
-  /*@Test
-  fun testConfirmButtonNavigatesAfterSavingImage() {
-    composeTestRule.setContent { ImageReviewScreen(mockNavigationActions, fakeFile,postsViewModel) }
 
-    // Click on the "Save Image" button
+  @Test
+  fun testImageDisplayedWhenImageFileIsNotNull() {
+    val imageFile = File("path/to/image")
+    composeTestRule.setContent {
+      ImageReviewScreen(
+        navigationActions = mockNavigationActions,
+        imageFile = imageFile, postsViewModel
+      )
+    }
+    composeTestRule.onNodeWithContentDescription("Captured Image").assertIsDisplayed()
+  }
+
+  @Test
+  fun testNoImageAvailableTextWhenImageFileIsNull() {
+    composeTestRule.setContent {
+      ImageReviewScreen(
+        navigationActions = mockNavigationActions,
+        imageFile = null, postsViewModel
+      )
+    }
+    composeTestRule.onNodeWithText("No image available").assertIsDisplayed()
+  }
+
+
+  @Test
+  fun testSaveImageButtonTriggersUpload() {
+    val imageFile = File("path/to/image")
+    composeTestRule.setContent {
+      ImageReviewScreen(
+        navigationActions = mockNavigationActions,
+        imageFile = imageFile, postsViewModel
+      )
+    }
     composeTestRule.onNodeWithTag("confirm_button").performClick()
+    }
 
-    // Wait for Compose to complete the interactions
-    composeTestRule.waitForIdle()
+  @Test
+  fun testDiscardImageButton() {
+    composeTestRule.setContent {
+      ImageReviewScreen(
+        navigationActions = mockNavigationActions,
+        imageFile = File("path/to/image"), postsViewModel
+      )
+    }
+    composeTestRule.onNodeWithTag("cancel_button").performClick()
+    verify(mockNavigationActions).navigateTo(Screen.TAKE_IMAGE)
 
-    // Verify that the navigation to Google Map happens after clicking save
-    verify(mockNavigationActions).navigateTo(Screen.GOOGLE_MAP)
-  }*/
+
+  }
 
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/image/ImageReviewKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/image/ImageReviewKtTest.kt
@@ -90,5 +90,4 @@ class ImageReviewTest {
     }
     composeTestRule.onNodeWithText("No image available").assertIsDisplayed()
   }
-
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/image/ImageReviewKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/image/ImageReviewKtTest.kt
@@ -5,34 +5,55 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.lookupgroup27.lookup.model.post.PostsRepository
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
 import com.github.lookupgroup27.lookup.ui.navigation.Screen
+import com.github.lookupgroup27.lookup.ui.post.PostsViewModel
 import java.io.File
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
 class ImageReviewTest {
 
+  private lateinit var postsViewModel: PostsViewModel
+  private lateinit var postsRepository: PostsRepository
+
   @get:Rule val composeTestRule = createComposeRule()
 
-  val fakeFile: File = File.createTempFile("temp", null)
+  private val fakeFile: File = File.createTempFile("temp", null)
 
   private val mockNavigationActions: NavigationActions = mock()
 
+  @Before
+  fun setUp() {
+    postsRepository = Mockito.mock(PostsRepository::class.java)
+    postsViewModel = PostsViewModel(postsRepository)
+
+    // Mock UID generator to return a fixed value
+    `when`(postsViewModel.generateNewUid()).thenReturn("mocked_uid")
+  }
+
   @Test
   fun testImageReviewIsDisplayed() {
-    composeTestRule.setContent { ImageReviewScreen(mockNavigationActions, fakeFile) }
+    composeTestRule.setContent {
+      ImageReviewScreen(mockNavigationActions, fakeFile, postsViewModel)
+    }
 
     composeTestRule.onNodeWithTag("image_review").assertIsDisplayed()
   }
 
   @Test
   fun testConfirmButtonIsDisplayedAndClickable() {
-    composeTestRule.setContent { ImageReviewScreen(mockNavigationActions, fakeFile) }
+    composeTestRule.setContent {
+      ImageReviewScreen(mockNavigationActions, fakeFile, postsViewModel)
+    }
 
     composeTestRule.onNodeWithTag("confirm_button").assertIsDisplayed()
     composeTestRule.onNodeWithTag("confirm_button").performClick()
@@ -40,11 +61,28 @@ class ImageReviewTest {
 
   @Test
   fun testCancelButtonIsDisplayedAndClickable() {
-    composeTestRule.setContent { ImageReviewScreen(mockNavigationActions, fakeFile) }
+    composeTestRule.setContent {
+      ImageReviewScreen(mockNavigationActions, fakeFile, postsViewModel)
+    }
 
     composeTestRule.onNodeWithTag("cancel_button").assertIsDisplayed()
     composeTestRule.onNodeWithTag("cancel_button").performClick()
 
     verify(mockNavigationActions).navigateTo(Screen.TAKE_IMAGE)
   }
+
+  /*@Test
+  fun testConfirmButtonNavigatesAfterSavingImage() {
+    composeTestRule.setContent { ImageReviewScreen(mockNavigationActions, fakeFile,postsViewModel) }
+
+    // Click on the "Save Image" button
+    composeTestRule.onNodeWithTag("confirm_button").performClick()
+
+    // Wait for Compose to complete the interactions
+    composeTestRule.waitForIdle()
+
+    // Verify that the navigation to Google Map happens after clicking save
+    verify(mockNavigationActions).navigateTo(Screen.GOOGLE_MAP)
+  }*/
+
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/image/TakeImageKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/image/TakeImageKtTest.kt
@@ -39,7 +39,7 @@ class TakeImageTest {
     composeTestRule.onNodeWithTag("go_back_button_camera").assertIsDisplayed()
     composeTestRule.onNodeWithTag("go_back_button_camera").performClick()
 
-    verify(mockNavigationActions).navigateTo(Screen.MENU)
+    verify(mockNavigationActions).navigateTo(Screen.GOOGLE_MAP)
   }
 
   @Test

--- a/app/src/main/java/com/github/lookupgroup27/lookup/MainActivity.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/MainActivity.kt
@@ -48,6 +48,7 @@ class MainActivity : ComponentActivity() {
     super.onCreate(savedInstanceState)
 
     auth = FirebaseAuth.getInstance()
+
     // auth.currentUser?.let { auth.signOut() }
 
     setContent { LookUpTheme { Surface(modifier = Modifier.fillMaxSize()) { LookUpApp() } } }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/MainActivity.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/MainActivity.kt
@@ -28,6 +28,7 @@ import com.github.lookupgroup27.lookup.ui.navigation.Route
 import com.github.lookupgroup27.lookup.ui.navigation.Screen
 import com.github.lookupgroup27.lookup.ui.overview.LandingScreen
 import com.github.lookupgroup27.lookup.ui.overview.MenuScreen
+import com.github.lookupgroup27.lookup.ui.post.PostsViewModel
 import com.github.lookupgroup27.lookup.ui.profile.CollectionScreen
 import com.github.lookupgroup27.lookup.ui.profile.ProfileInformationScreen
 import com.github.lookupgroup27.lookup.ui.profile.ProfileScreen
@@ -61,6 +62,7 @@ fun LookUpApp() {
   val quizViewModel: QuizViewModel =
       viewModel(factory = QuizViewModel.provideFactory(context = LocalContext.current))
   val profileViewModel: ProfileViewModel = viewModel(factory = ProfileViewModel.Factory)
+  val postsViewModel: PostsViewModel = viewModel(factory = PostsViewModel.Factory)
 
   NavHost(navController = navController, startDestination = Route.LANDING) {
     navigation(
@@ -87,7 +89,7 @@ fun LookUpApp() {
       composable(Screen.MENU) { MenuScreen(navigationActions) }
       composable(Screen.PROFILE) { ProfileScreen(navigationActions) }
       composable(Screen.CALENDAR) { CalendarScreen(calendarViewModel, navigationActions) }
-      composable(Screen.GOOGLE_MAP) { GoogleMapScreen(navigationActions) }
+      composable(Screen.GOOGLE_MAP) { GoogleMapScreen(navigationActions, postsViewModel) }
       composable(Screen.QUIZ) { QuizScreen(quizViewModel, navigationActions) }
     }
 
@@ -113,7 +115,10 @@ fun LookUpApp() {
         arguments = listOf(navArgument("imageFile") { type = NavType.StringType })) { backStackEntry
           ->
           val imageFile = backStackEntry.arguments?.getString("imageFile")?.let { File(it) }
-          ImageReviewScreen(navigationActions = navigationActions, imageFile = imageFile)
+          ImageReviewScreen(
+              navigationActions = navigationActions,
+              imageFile = imageFile,
+              postsViewModel = postsViewModel)
         }
 
     navigation(startDestination = Screen.FEED, route = Route.FEED) {

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/location/LocationProviderSingleton.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/location/LocationProviderSingleton.kt
@@ -1,0 +1,28 @@
+package com.github.lookupgroup27.lookup.model.location
+
+import android.content.Context
+
+/**
+ * Singleton object to manage a single instance of LocationProvider. This ensures only one instance
+ * of LocationProvider is created and shared across the app.
+ */
+object LocationProviderSingleton {
+
+  // Holds the single instance of LocationProvider, initially null
+  private var instance: LocationProvider? = null
+
+  /**
+   * Retrieves the single instance of LocationProvider. If it hasn't been created yet, a new
+   * instance is created using the application context.
+   *
+   * @param context Application context to initialize LocationProvider if needed.
+   * @return The singleton instance of LocationProvider.
+   */
+  fun getInstance(context: Context): LocationProvider {
+    // Initialize instance if it's null, otherwise return the existing instance
+    if (instance == null) {
+      instance = LocationProvider(context.applicationContext)
+    }
+    return instance!!
+  }
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/post/PostsRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/post/PostsRepositoryFirestore.kt
@@ -40,8 +40,8 @@ class PostsRepositoryFirestore(private val db: FirebaseFirestore) : PostsReposit
                       data["uri"] as String,
                       data["username"] as String,
                       (data["likes"] as? Long)?.toInt() ?: 0,
-                      (data["latitude"] as? Long)?.toDouble() ?: 0.0,
-                      (data["longitude"] as? Long)?.toDouble() ?: 0.0,
+                      data["latitude"] as Double,
+                      data["longitude"] as Double
                   )
                 }
                 .filterNotNull()

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/post/PostsRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/post/PostsRepositoryFirestore.kt
@@ -41,8 +41,7 @@ class PostsRepositoryFirestore(private val db: FirebaseFirestore) : PostsReposit
                       data["username"] as String,
                       (data["likes"] as? Long)?.toInt() ?: 0,
                       data["latitude"] as Double,
-                      data["longitude"] as Double
-                  )
+                      data["longitude"] as Double)
                 }
                 .filterNotNull()
         onSuccess(posts)

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/GoogleMap.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/GoogleMap.kt
@@ -39,7 +39,6 @@ import com.google.firebase.auth.FirebaseAuth
  * @param navigationActions Actions to navigate to different screens.
  * @param postsViewModel ViewModel to fetch posts.
  */
-
 private const val LOCATION_PERMISSION_REQUEST_CODE = 1001
 
 @Composable
@@ -89,6 +88,8 @@ fun GoogleMapScreen(
               if (isLoggedIn) {
                 navigationActions.navigateTo(Screen.TAKE_IMAGE)
               } else {
+                Toast.makeText(context, "Please log in to take a picture.", Toast.LENGTH_LONG)
+                    .show()
                 navigationActions.navigateTo(Screen.AUTH)
               }
             },

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/GoogleMap.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/GoogleMap.kt
@@ -3,25 +3,13 @@ package com.github.lookupgroup27.lookup.ui.googlemap
 import android.Manifest
 import android.app.Activity
 import android.content.pm.PackageManager
-import android.location.Location
-import android.util.Log
 import android.widget.Toast
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material3.Button
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -30,32 +18,27 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.lookupgroup27.lookup.model.location.LocationProviderSingleton
-import com.github.lookupgroup27.lookup.model.post.Post
-import com.github.lookupgroup27.lookup.ui.image.ImagePreviewDialog
+import com.github.lookupgroup27.lookup.ui.googlemap.components.MapControls
+import com.github.lookupgroup27.lookup.ui.googlemap.components.MapView
 import com.github.lookupgroup27.lookup.ui.navigation.BottomNavigationMenu
 import com.github.lookupgroup27.lookup.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
 import com.github.lookupgroup27.lookup.ui.navigation.Screen
 import com.github.lookupgroup27.lookup.ui.post.PostsViewModel
-import com.google.android.gms.maps.CameraUpdateFactory
-import com.google.android.gms.maps.model.BitmapDescriptorFactory
-import com.google.android.gms.maps.model.LatLng
 import com.google.firebase.auth.FirebaseAuth
-import com.google.maps.android.compose.GoogleMap
-import com.google.maps.android.compose.MapProperties
-import com.google.maps.android.compose.MapType
-import com.google.maps.android.compose.MapUiSettings
-import com.google.maps.android.compose.Marker
-import com.google.maps.android.compose.MarkerState
-import com.google.maps.android.compose.rememberCameraPositionState
+
+/**
+ * Screen that displays a Google Map with user's location and posts.
+ *
+ * @param navigationActions Actions to navigate to different screens.
+ * @param postsViewModel ViewModel to fetch posts.
+ */
 
 private const val LOCATION_PERMISSION_REQUEST_CODE = 1001
 
@@ -116,22 +99,10 @@ fun GoogleMapScreen(
       content = { padding ->
         Column {
           // Buttons to toggle map modes
-          Box(
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .background(Color(0xFF0D1023)) // Dark blue
-                      .padding(16.dp)) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween) {
-                      Button(onClick = { autoCenteringEnabled = true }) {
-                        Text(text = "Auto Center On")
-                      }
-                      Button(onClick = { autoCenteringEnabled = false }) {
-                        Text(text = "Auto Center Off")
-                      }
-                    }
-              }
+
+          MapControls(
+              autoCenteringEnabled = autoCenteringEnabled,
+              onCenteringToggle = { autoCenteringEnabled = it })
 
           // Map view below the buttons
           MapView(
@@ -142,73 +113,4 @@ fun GoogleMapScreen(
               allPosts)
         }
       })
-}
-
-@Composable
-fun MapView(
-    padding: PaddingValues,
-    hasLocationPermission: Boolean,
-    location: Location?,
-    autoCenteringEnabled: Boolean,
-    posts: List<Post>
-) {
-
-  var mapProperties by remember {
-    mutableStateOf(
-        MapProperties(
-            mapType = MapType.NORMAL,
-        ))
-  }
-  var mapUiSettings by remember { mutableStateOf(MapUiSettings(zoomControlsEnabled = false)) }
-  val cameraPositionState = rememberCameraPositionState()
-
-  // Enable location layer only when permissions are granted
-  LaunchedEffect(hasLocationPermission) {
-    if (hasLocationPermission) {
-      mapProperties = mapProperties.copy(isMyLocationEnabled = true)
-    }
-  }
-
-  // State for showing image preview dialog
-  var selectedPost by remember { mutableStateOf<Post?>(null) }
-
-  // Update the camera position whenever location changes
-  LaunchedEffect(location, autoCenteringEnabled) {
-    if (hasLocationPermission && location != null && autoCenteringEnabled) {
-      val latLng = LatLng(location.latitude, location.longitude)
-      val cameraUpdate = CameraUpdateFactory.newLatLngZoom(latLng, 5f)
-      cameraPositionState.animate(cameraUpdate)
-    }
-  }
-
-  GoogleMap(
-      modifier = Modifier.fillMaxSize().padding(padding),
-      properties = mapProperties,
-      uiSettings = mapUiSettings,
-      cameraPositionState = cameraPositionState) {
-        // Add markers for each post
-        posts.forEach { post ->
-          val latLng = LatLng(post.latitude, post.longitude)
-          Log.d(
-              "MapView",
-              "Adding marker at (${post.latitude}, ${post.longitude}) for URI: ${post.uri}")
-          Marker(
-              state = MarkerState(position = latLng),
-              title = post.username,
-              icon =
-                  BitmapDescriptorFactory.defaultMarker(
-                      BitmapDescriptorFactory.HUE_AZURE), // Change color
-              onClick = {
-                // When the marker is clicked, open the image preview dialog
-                selectedPost = post
-                true
-              })
-        }
-
-        // Display the ImagePreviewDialog when a post is selected
-        selectedPost?.let {
-          ImagePreviewDialog(
-              uri = it.uri, username = it.username, onDismiss = { selectedPost = null })
-        }
-      }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/GoogleMap.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/GoogleMap.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.app.Activity
 import android.content.pm.PackageManager
 import android.location.Location
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -14,11 +15,16 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Button
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -30,12 +36,19 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import com.github.lookupgroup27.lookup.model.location.LocationProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.lookupgroup27.lookup.model.location.LocationProviderSingleton
+import com.github.lookupgroup27.lookup.model.post.Post
+import com.github.lookupgroup27.lookup.model.post.PostsViewModel
+import com.github.lookupgroup27.lookup.ui.image.ImagePreviewDialog
 import com.github.lookupgroup27.lookup.ui.navigation.BottomNavigationMenu
 import com.github.lookupgroup27.lookup.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
+import com.github.lookupgroup27.lookup.ui.navigation.Screen
 import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.LatLng
+import com.google.firebase.auth.FirebaseAuth
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.MapType
@@ -47,11 +60,15 @@ import com.google.maps.android.compose.rememberCameraPositionState
 private const val LOCATION_PERMISSION_REQUEST_CODE = 1001
 
 @Composable
-fun GoogleMapScreen(navigationActions: NavigationActions) {
+fun GoogleMapScreen(navigationActions: NavigationActions, postsViewModel: PostsViewModel = viewModel()) {
   val context = LocalContext.current
   var hasLocationPermission by remember { mutableStateOf(false) }
-  val locationProvider = remember { LocationProvider(context) }
+    val locationProvider = LocationProviderSingleton.getInstance(context)
   var autoCenteringEnabled by remember { mutableStateOf(true) } // New state for auto-centering
+    val auth = remember { FirebaseAuth.getInstance() }
+    val isLoggedIn = auth.currentUser != null
+
+    val allPosts by postsViewModel.allPosts.collectAsState()
 
   LaunchedEffect(Unit) {
     hasLocationPermission =
@@ -79,13 +96,27 @@ fun GoogleMapScreen(navigationActions: NavigationActions) {
             tabList = LIST_TOP_LEVEL_DESTINATION,
             selectedItem = navigationActions.currentRoute())
       },
+      floatingActionButton = {
+          FloatingActionButton(
+              onClick = {
+                  if (isLoggedIn) {
+                      navigationActions.navigateTo(Screen.TAKE_IMAGE)
+                  } else {
+                      navigationActions.navigateTo(Screen.AUTH)
+                  }
+              },
+              modifier = Modifier.testTag("fab_take_picture")
+          ) {
+              Icon(Icons.Default.Add, contentDescription = "Take Picture")
+          }
+      },
       content = { padding ->
         Column {
           // Add buttons to toggle map modes
           Box(
               modifier =
                   Modifier.fillMaxWidth()
-                      .background(Color(0xFF0D1023)) // Set your desired color here
+                      .background(Color(0xFF0D1023)) // Dark blue
                       .padding(16.dp)) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -104,10 +135,13 @@ fun GoogleMapScreen(navigationActions: NavigationActions) {
               padding,
               hasLocationPermission,
               locationProvider.currentLocation.value,
-              autoCenteringEnabled // Pass the state
+              autoCenteringEnabled, // Pass the state
+              allPosts
               )
         }
-      })
+      }
+
+  )
 }
 
 @Composable
@@ -115,31 +149,75 @@ fun MapView(
     padding: PaddingValues,
     hasLocationPermission: Boolean,
     location: Location?,
-    autoCenteringEnabled: Boolean
+    autoCenteringEnabled: Boolean,
+    posts: List<Post>
 ) {
-  var mapProperties by remember { mutableStateOf(MapProperties(mapType = MapType.NORMAL)) }
-  var mapUiSettings by remember { mutableStateOf(MapUiSettings(zoomControlsEnabled = false)) }
-  val cameraPositionState = rememberCameraPositionState()
-
-  // Update the camera position whenever location changes
-  LaunchedEffect(location, autoCenteringEnabled) {
-    if (hasLocationPermission && location != null && autoCenteringEnabled) {
-      val latLng = LatLng(location.latitude, location.longitude)
-      val cameraUpdate = CameraUpdateFactory.newLatLngZoom(latLng, 5f)
-      cameraPositionState.animate(cameraUpdate)
+    //var mapProperties by remember { mutableStateOf(MapProperties(mapType = MapType.NORMAL)) }
+    var mapProperties by remember {
+        mutableStateOf(
+            MapProperties(
+                mapType = MapType.NORMAL,
+                //isMyLocationEnabled = false // Enable the my location layer
+            )
+        )
     }
-  }
+    var mapUiSettings by remember { mutableStateOf(MapUiSettings(zoomControlsEnabled = false)) }
+    val cameraPositionState = rememberCameraPositionState()
 
-  GoogleMap(
-      modifier = Modifier.fillMaxSize().padding(padding),
-      properties = mapProperties,
-      uiSettings = mapUiSettings,
-      cameraPositionState = cameraPositionState) {
-        if (hasLocationPermission && location != null) {
-          val latLng = LatLng(location.latitude, location.longitude)
-          Marker(state = MarkerState(position = latLng), title = "You are here")
-        } else {
-          //  case where location is not available
+    // Enable location layer only when permissions are granted
+    LaunchedEffect(hasLocationPermission) {
+        if (hasLocationPermission) {
+            mapProperties = mapProperties.copy(isMyLocationEnabled = true)
         }
-      }
+    }
+
+    // State for showing image preview dialog
+    var selectedPost by remember { mutableStateOf<Post?>(null) }
+
+    // Update the camera position whenever location changes
+    LaunchedEffect(location, autoCenteringEnabled) {
+        if (hasLocationPermission && location != null && autoCenteringEnabled) {
+            val latLng = LatLng(location.latitude, location.longitude)
+            val cameraUpdate = CameraUpdateFactory.newLatLngZoom(latLng, 5f)
+            cameraPositionState.animate(cameraUpdate)
+        }
+    }
+
+    GoogleMap(
+        modifier = Modifier.fillMaxSize().padding(padding),
+        properties = mapProperties,
+        uiSettings = mapUiSettings,
+        cameraPositionState = cameraPositionState
+    ) {
+        // Add markers for each post
+        posts.forEach { post ->
+            val latLng = LatLng(post.latitude, post.longitude)
+            Log.d("MapView", "Adding marker at (${post.latitude}, ${post.longitude}) for URI: ${post.uri}")
+            Marker(
+                state = MarkerState(position = latLng),
+                title = post.username,
+                icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE), // Change color
+                onClick = {
+                    // When the marker is clicked, open the image preview dialog
+                    selectedPost = post
+                    true
+                }
+            )
+        }
+
+        // Display the ImagePreviewDialog when a post is selected
+        selectedPost?.let {
+            ImagePreviewDialog(
+                uri = it.uri,
+                username = it.username,
+                onDismiss = { selectedPost = null }
+            )
+        }
+
+        // Add a marker for the user's current location
+        /*if (hasLocationPermission && location != null) {
+            val latLng = LatLng(location.latitude, location.longitude)
+            Marker(state = MarkerState(position = latLng), title = "You are here")
+       }*/
+    }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/components/AddMapMarker.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/components/AddMapMarker.kt
@@ -1,0 +1,27 @@
+package com.github.lookupgroup27.lookup.ui.googlemap.components
+
+import androidx.compose.runtime.Composable
+import com.github.lookupgroup27.lookup.model.post.Post
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
+
+/**
+ * Add a marker to the map
+ *
+ * @param post The post to add a marker for
+ * @param onMarkerClick The callback to be called when the marker is clicked
+ */
+@Composable
+fun AddMapMarker(post: Post, onMarkerClick: (Post) -> Unit) {
+  val latLng = LatLng(post.latitude, post.longitude)
+  Marker(
+      state = MarkerState(position = latLng),
+      title = post.username,
+      icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE),
+      onClick = {
+        onMarkerClick(post)
+        true
+      })
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/components/MapControls.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/components/MapControls.kt
@@ -1,0 +1,30 @@
+package com.github.lookupgroup27.lookup.ui.googlemap.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.github.lookupgroup27.lookup.ui.theme.*
+
+/**
+ * Map controls for toggling auto centering
+ *
+ * @param autoCenteringEnabled Whether auto centering is enabled
+ * @param onCenteringToggle The callback to be called when the auto centering is toggled
+ */
+@Composable
+fun MapControls(autoCenteringEnabled: Boolean, onCenteringToggle: (Boolean) -> Unit) {
+  Box(modifier = Modifier.fillMaxWidth().background(DarkBlue).padding(16.dp)) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+      Button(onClick = { onCenteringToggle(true) }) { Text(text = "Auto Center On") }
+      Button(onClick = { onCenteringToggle(false) }) { Text(text = "Auto Center Off") }
+    }
+  }
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/components/MapView.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/components/MapView.kt
@@ -1,0 +1,90 @@
+package com.github.lookupgroup27.lookup.ui.googlemap.components
+
+import android.location.Location
+import android.util.Log
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.github.lookupgroup27.lookup.model.post.Post
+import com.github.lookupgroup27.lookup.ui.image.ImagePreviewDialog
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.MapProperties
+import com.google.maps.android.compose.MapType
+import com.google.maps.android.compose.MapUiSettings
+import com.google.maps.android.compose.rememberCameraPositionState
+
+/**
+ * Composable that displays a Google Map with markers for posts.
+ *
+ * @param padding Padding values for the map
+ * @param hasLocationPermission Whether the app has location permission
+ * @param location The user's location
+ * @param autoCenteringEnabled Whether auto centering is enabled
+ * @param posts The list of posts to display on the map
+ */
+@Composable
+fun MapView(
+    padding: PaddingValues,
+    hasLocationPermission: Boolean,
+    location: Location?,
+    autoCenteringEnabled: Boolean,
+    posts: List<Post>
+) {
+
+  var mapProperties by remember {
+    mutableStateOf(
+        MapProperties(
+            mapType = MapType.NORMAL,
+        ))
+  }
+  var mapUiSettings by remember { mutableStateOf(MapUiSettings(zoomControlsEnabled = false)) }
+  val cameraPositionState = rememberCameraPositionState()
+
+  // Enable location layer only when permissions are granted
+  LaunchedEffect(hasLocationPermission) {
+    if (hasLocationPermission) {
+      mapProperties = mapProperties.copy(isMyLocationEnabled = true)
+    }
+  }
+
+  // State for showing image preview dialog
+  var selectedPost by remember { mutableStateOf<Post?>(null) }
+
+  // Update the camera position whenever location changes
+  LaunchedEffect(location, autoCenteringEnabled) {
+    if (hasLocationPermission && location != null && autoCenteringEnabled) {
+      val latLng = LatLng(location.latitude, location.longitude)
+      val cameraUpdate = CameraUpdateFactory.newLatLngZoom(latLng, 5f)
+      cameraPositionState.animate(cameraUpdate)
+    }
+  }
+
+  GoogleMap(
+      modifier = Modifier.fillMaxSize().padding(padding),
+      properties = mapProperties,
+      uiSettings = mapUiSettings,
+      cameraPositionState = cameraPositionState) {
+        // Add markers for each post
+        posts.forEach { post ->
+          Log.d(
+              "MapView",
+              "Adding marker at (${post.latitude}, ${post.longitude}) for URI: ${post.uri}")
+          AddMapMarker(post) { clickedPost -> selectedPost = clickedPost }
+        }
+
+        // Display the ImagePreviewDialog when a post is selected
+        selectedPost?.let {
+          ImagePreviewDialog(
+              uri = it.uri, username = it.username, onDismiss = { selectedPost = null })
+        }
+      }
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImagePreviewDialog.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImagePreviewDialog.kt
@@ -19,6 +19,15 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import coil.compose.rememberAsyncImagePainter
+import com.github.lookupgroup27.lookup.ui.theme.*
+
+/**
+ * Display a dialog with an image preview.
+ *
+ * @param uri The URI of the image to display.
+ * @param username The username of the user who posted the image.
+ * @param onDismiss The callback to be invoked when the dialog is dismissed.
+ */
 
 // Display a dialog with an image preview
 @Composable
@@ -28,10 +37,7 @@ fun ImagePreviewDialog(uri: String?, username: String?, onDismiss: () -> Unit) {
         onDismissRequest =
             onDismiss) { // Dismiss the dialog when the user clicks outside the dialog
           Column(
-              modifier =
-                  Modifier.padding(16.dp)
-                      .background(Color(0xFF0D1023))
-                      .testTag("imagePreviewDialog"),
+              modifier = Modifier.padding(16.dp).background(DarkBlue).testTag("imagePreviewDialog"),
               horizontalAlignment = Alignment.CenterHorizontally) {
                 if (username != null) {
                   Text(

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImagePreviewDialog.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImagePreviewDialog.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.*
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -16,40 +15,39 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import coil.compose.rememberAsyncImagePainter
 
+// Display a dialog with an image preview
 @Composable
 fun ImagePreviewDialog(uri: String?, username: String?, onDismiss: () -> Unit) {
-    if (uri != null) {
-        Dialog(onDismissRequest = onDismiss) {
-            Column(
-                modifier = Modifier
-                    .padding(16.dp)
-                    .background(Color(0xFF0D1023)),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
+  if (uri != null) {
+    Dialog(
+        onDismissRequest =
+            onDismiss) { // Dismiss the dialog when the user clicks outside the dialog
+          Column(
+              modifier =
+                  Modifier.padding(16.dp)
+                      .background(Color(0xFF0D1023))
+                      .testTag("imagePreviewDialog"),
+              horizontalAlignment = Alignment.CenterHorizontally) {
                 if (username != null) {
-                    Text(
-                        text = "Posted by: $username",
-                        modifier = Modifier.padding(bottom = 8.dp),
-                        color = Color.White
-                    )
+                  Text(
+                      text = "Posted by: $username",
+                      modifier = Modifier.padding(bottom = 8.dp),
+                      color = Color.White)
                 }
                 Image(
+                    // Load the image from the provided URI
                     painter = rememberAsyncImagePainter(uri),
                     contentDescription = "Image Preview",
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(1f),
-                    contentScale = ContentScale.Crop
-                )
+                    modifier = Modifier.fillMaxWidth().aspectRatio(1f),
+                    contentScale = ContentScale.Crop)
                 Spacer(modifier = Modifier.height(16.dp))
-                Button(onClick = onDismiss) {
-                    Text(text = "Close")
-                }
-            }
+                Button(onClick = onDismiss) { Text(text = "Close") }
+              }
         }
-    }
+  }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImagePreviewDialog.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImagePreviewDialog.kt
@@ -1,0 +1,55 @@
+package com.github.lookupgroup27.lookup.ui.image
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.*
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import coil.compose.rememberAsyncImagePainter
+
+@Composable
+fun ImagePreviewDialog(uri: String?, username: String?, onDismiss: () -> Unit) {
+    if (uri != null) {
+        Dialog(onDismissRequest = onDismiss) {
+            Column(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .background(Color(0xFF0D1023)),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                if (username != null) {
+                    Text(
+                        text = "Posted by: $username",
+                        modifier = Modifier.padding(bottom = 8.dp),
+                        color = Color.White
+                    )
+                }
+                Image(
+                    painter = rememberAsyncImagePainter(uri),
+                    contentDescription = "Image Preview",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(1f),
+                    contentScale = ContentScale.Crop
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Button(onClick = onDismiss) {
+                    Text(text = "Close")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImageReview.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImageReview.kt
@@ -64,9 +64,7 @@ fun ImageReviewScreen(
         // Save Image Button
 
         Button(
-            onClick = {
-              imageFile?.let { imageViewModel.uploadImage(it) }
-              },
+            onClick = { imageFile?.let { imageViewModel.uploadImage(it) } },
             modifier = Modifier.fillMaxWidth().testTag("confirm_button")) {
               Text(text = "Save Image")
             }
@@ -83,37 +81,38 @@ fun ImageReviewScreen(
               Text(text = "Discard Image")
             }
 
-      // Display upload status messages and create a post upon successful upload
-      when {
+        // Display upload status messages and create a post upon successful upload
+        when {
           uploadStatus.isLoading ->
               Text(text = "Uploading...", modifier = Modifier.padding(top = 16.dp))
           uploadStatus.downloadUrl != null -> {
-              val downloadUrl = uploadStatus.downloadUrl // Get the download URL from upload status
-              val currentLocation = locationProvider.currentLocation.value
-              if (downloadUrl != null && currentLocation != null) {
-                  // Create a new post with the image download URL and current location
-                  val newPost = Post(
+            val downloadUrl = uploadStatus.downloadUrl // Get the download URL from upload status
+            val currentLocation = locationProvider.currentLocation.value
+            if (downloadUrl != null && currentLocation != null) {
+              // Create a new post with the image download URL and current location
+              val newPost =
+                  Post(
                       uid = postsViewModel.generateNewUid(),
                       uri = downloadUrl,
                       username = FirebaseAuth.getInstance().currentUser?.displayName ?: "Anonymous",
                       latitude = currentLocation.latitude,
-                      longitude = currentLocation.longitude
-                  )
-                  // Add the post to PostsViewModel
-                  postsViewModel.addPost(newPost)
-                  Toast.makeText(context, "Image saved", Toast.LENGTH_SHORT).show()
-                  navigationActions.navigateTo(Screen.GOOGLE_MAP)
-              } else {
-                  Toast.makeText(context, "Failed to get current location or download URL", Toast.LENGTH_SHORT).show()
-              }
-              imageViewModel.resetUploadStatus() // Reset status after handling
+                      longitude = currentLocation.longitude)
+              // Add the post to PostsViewModel
+              postsViewModel.addPost(newPost)
+              Toast.makeText(context, "Image saved", Toast.LENGTH_SHORT).show()
+              navigationActions.navigateTo(Screen.GOOGLE_MAP)
+            } else {
+              Toast.makeText(
+                      context, "Failed to get current location or download URL", Toast.LENGTH_SHORT)
+                  .show()
+            }
+            imageViewModel.resetUploadStatus() // Reset status after handling
           }
           uploadStatus.errorMessage != null -> {
-              Text(
-                  text = "Error: ${uploadStatus.errorMessage}",
-                  modifier = Modifier.padding(top = 16.dp)
-              )
+            Text(
+                text = "Error: ${uploadStatus.errorMessage}",
+                modifier = Modifier.padding(top = 16.dp))
           }
+        }
       }
-  }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImageReview.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImageReview.kt
@@ -66,30 +66,7 @@ fun ImageReviewScreen(
         Button(
             onClick = {
               imageFile?.let { imageViewModel.uploadImage(it) }
-              if (imageFile != null) {
-                // Get the user's current location
-                val currentLocation = locationProvider.currentLocation.value
-                if (currentLocation != null) {
-                  // Create a new post with the image URI and current location
-                  val newPost =
-                      Post(
-                          uid = postsViewModel.generateNewUid(),
-                          uri = imageFile.toURI().toString(),
-                          username =
-                              FirebaseAuth.getInstance().currentUser?.displayName ?: "Anonymous",
-                          latitude = currentLocation.latitude,
-                          longitude = currentLocation.longitude)
-                  // Add the post to PostsViewModel
-                  postsViewModel.addPost(newPost)
-                } else {
-                  Toast.makeText(context, "Failed to get current location", Toast.LENGTH_SHORT)
-                      .show()
-                  return@Button
-                }
-              }
-              Toast.makeText(context, "Image saved", Toast.LENGTH_SHORT).show()
-              navigationActions.navigateTo(Screen.GOOGLE_MAP)
-            },
+              },
             modifier = Modifier.fillMaxWidth().testTag("confirm_button")) {
               Text(text = "Save Image")
             }
@@ -106,20 +83,37 @@ fun ImageReviewScreen(
               Text(text = "Discard Image")
             }
 
-        // Display upload status messages
-        when {
+      // Display upload status messages and create a post upon successful upload
+      when {
           uploadStatus.isLoading ->
               Text(text = "Uploading...", modifier = Modifier.padding(top = 16.dp))
           uploadStatus.downloadUrl != null -> {
-            Toast.makeText(context, "Image uploaded successfully!", Toast.LENGTH_SHORT).show()
-            navigationActions.navigateTo(Screen.TAKE_IMAGE) // Navigate after successful upload
-            imageViewModel.resetUploadStatus() // Reset status after handling
+              val downloadUrl = uploadStatus.downloadUrl // Get the download URL from upload status
+              val currentLocation = locationProvider.currentLocation.value
+              if (downloadUrl != null && currentLocation != null) {
+                  // Create a new post with the image download URL and current location
+                  val newPost = Post(
+                      uid = postsViewModel.generateNewUid(),
+                      uri = downloadUrl,
+                      username = FirebaseAuth.getInstance().currentUser?.displayName ?: "Anonymous",
+                      latitude = currentLocation.latitude,
+                      longitude = currentLocation.longitude
+                  )
+                  // Add the post to PostsViewModel
+                  postsViewModel.addPost(newPost)
+                  Toast.makeText(context, "Image saved", Toast.LENGTH_SHORT).show()
+                  navigationActions.navigateTo(Screen.GOOGLE_MAP)
+              } else {
+                  Toast.makeText(context, "Failed to get current location or download URL", Toast.LENGTH_SHORT).show()
+              }
+              imageViewModel.resetUploadStatus() // Reset status after handling
           }
           uploadStatus.errorMessage != null -> {
-            Text(
-                text = "Error: ${uploadStatus.errorMessage}",
-                modifier = Modifier.padding(top = 16.dp))
+              Text(
+                  text = "Error: ${uploadStatus.errorMessage}",
+                  modifier = Modifier.padding(top = 16.dp)
+              )
           }
-        }
       }
+  }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImageReview.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImageReview.kt
@@ -62,6 +62,7 @@ fun ImageReviewScreen(
         Spacer(modifier = Modifier.height(24.dp))
 
         // Save Image Button
+
         Button(
             onClick = {
               imageFile?.let { imageViewModel.uploadImage(it) }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/TakeImage.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/TakeImage.kt
@@ -91,7 +91,7 @@ fun CameraCapture(
           })
 
       IconButton(
-          onClick = { navigationActions.navigateTo(Screen.MENU) },
+          onClick = { navigationActions.navigateTo(Screen.GOOGLE_MAP) },
           modifier =
               Modifier.padding(16.dp).align(Alignment.TopStart).testTag("go_back_button_camera")) {
             Icon(

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/post/PostsViewModel.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/post/PostsViewModel.kt
@@ -3,10 +3,14 @@ package com.github.lookupgroup27.lookup.ui.post
 import android.util.Log
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import com.github.lookupgroup27.lookup.model.post.Post
 import com.github.lookupgroup27.lookup.model.post.PostsRepository
+import com.github.lookupgroup27.lookup.model.post.PostsRepositoryFirestore
+import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.firestore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -67,5 +71,15 @@ class PostsViewModel(private val repository: PostsRepository) : ViewModel() {
 
   fun updatePost(post: Post, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
     repository.updatePost(post, onSuccess, onFailure)
+  }
+
+  companion object {
+    val Factory: ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+          @Suppress("UNCHECKED_CAST")
+          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return PostsViewModel(PostsRepositoryFirestore(Firebase.firestore)) as T
+          }
+        }
   }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/post/PostsViewModel.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/post/PostsViewModel.kt
@@ -73,7 +73,6 @@ class PostsViewModel(private val repository: PostsRepository) : ViewModel() {
     repository.updatePost(post, onSuccess, onFailure)
   }
 
-
   companion object {
     val Factory: ViewModelProvider.Factory =
         object : ViewModelProvider.Factory {

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/post/PostsViewModel.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/post/PostsViewModel.kt
@@ -73,6 +73,7 @@ class PostsViewModel(private val repository: PostsRepository) : ViewModel() {
     repository.updatePost(post, onSuccess, onFailure)
   }
 
+
   companion object {
     val Factory: ViewModelProvider.Factory =
         object : ViewModelProvider.Factory {

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/theme/Color.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/theme/Color.kt
@@ -12,3 +12,5 @@ val StarWhite = Color(0xFFFFFFFF) // Light color for text on dark backgrounds
 val MeteorGrey = Color(0xFF333333) // Subtle grey for background contrast
 
 val DarkPurple = Color(0xFF30315B)
+
+val DarkBlue = Color(0xFF0D1023) // Dark blue


### PR DESCRIPTION
This pull request implements the feature to allow users to take pictures and add markers on the map at the location where the picture was taken. The following changes have been made:

- Added Picture Markers on Google Map: Users can now add markers on the map to indicate where they captured a picture. When clicking a marker, an image preview dialog opens to display the picture along with the username of the person who posted it.
- Floating Action Button for Capturing Images: Added a FAB button on the map screen to allow users to take pictures directly. (when the user is not logged in, the FAB leads to the sign in screen)
- Current User Location as Blue Dot: The user's current location is now represented as the standard blue dot on the Google map instead of a marker.
- Image Review Updates: After taking a picture, saving it adds a new post with location data, which is then used to create a marker on the map.
- ImagePreviewDialog: Added a new composable dialog to show a preview of images associated with map markers, including information on who posted them.

Note:
The LocationProviderSingleton object has been taken from PR #117 (it was needed for the code to work)
