### PR TITLE
Fix Go Back Button Position on Sign-In Screen and Add Regression Test

### DIFF
--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/authentication/SignInKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/authentication/SignInKtTest.kt
@@ -105,6 +105,20 @@ class SignInKtTest : TestCase() {
     resetOrientation()
   }
 
+  @Test
+  fun backArrowIsInTopLeftCorner() {
+    composeTestRule.setContent { SignInScreen(mockNavigationActions) }
+
+    val backArrowBounds =
+        composeTestRule.onNodeWithTag("go_back_button_signin").fetchSemanticsNode().boundsInRoot
+
+    val screenWidth = composeTestRule.onRoot().fetchSemanticsNode().boundsInRoot.width
+    val screenHeight = composeTestRule.onRoot().fetchSemanticsNode().boundsInRoot.height
+
+    assert(backArrowBounds.left < screenWidth * 0.1f)
+    assert(backArrowBounds.top < screenHeight * 0.1f)
+  }
+
   private fun setLandscapeOrientation() {
     val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
     device.setOrientationLeft()

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/authentication/SignInKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/authentication/SignInKtTest.kt
@@ -64,7 +64,7 @@ class SignInKtTest : TestCase() {
     composeTestRule.setContent { SignInScreen(mockNavigationActions) }
 
     // Scroll to ensure the go-back button is visible
-    composeTestRule.onNodeWithTag("go_back_button_signin").performScrollTo().assertIsDisplayed()
+    composeTestRule.onNodeWithTag("go_back_button_signin").assertIsDisplayed()
   }
 
   @Test
@@ -72,7 +72,7 @@ class SignInKtTest : TestCase() {
     composeTestRule.setContent { SignInScreen(mockNavigationActions) }
 
     // Perform click on the go-back button after scrolling to it
-    composeTestRule.onNodeWithTag("go_back_button_signin").performScrollTo().performClick()
+    composeTestRule.onNodeWithTag("go_back_button_signin").performClick()
     composeTestRule.waitForIdle()
 
     // Assert that the user is navigated back to the previous screen
@@ -97,7 +97,6 @@ class SignInKtTest : TestCase() {
         .assertHasClickAction()
     composeTestRule
         .onNodeWithTag("go_back_button_signin")
-        .performScrollTo()
         .assertIsDisplayed()
         .assertHasClickAction()
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/authentication/SignIn.kt
@@ -75,7 +75,17 @@ fun SignInScreen(navigationActions: NavigationActions) {
       containerColor = Color.Black,
       topBar = {
         TopAppBar(
-            title = { Text("") },
+            title = {},
+            navigationIcon = {
+              IconButton(
+                  onClick = { navigationActions.goBack() },
+                  modifier = Modifier.testTag("go_back_button_signin")) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Go Back",
+                        tint = Color.White)
+                  }
+            },
             colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Black))
       },
       content = { padding ->
@@ -87,18 +97,6 @@ fun SignInScreen(navigationActions: NavigationActions) {
                         rememberScrollState()), // Enable vertical scrolling in all orientations
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center) {
-              IconButton(
-                  onClick = { navigationActions.goBack() },
-                  modifier =
-                      Modifier.padding(16.dp)
-                          .align(Alignment.Start)
-                          .testTag("go_back_button_signin")) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Go Back",
-                        tint = Color.White)
-                  }
-
               Spacer(modifier = Modifier.height(16.dp))
 
               Image(


### PR DESCRIPTION
## Description  
This PR addresses the misalignment issue of the "Go Back" button on the Sign-In screen. The button is now correctly positioned in the top-left corner. A regression test has been added to verify that the button remains in the correct position in future updates.

### Added Tests  
- Implemented a regression test to check that the "Go Back" button remains in the top-left corner of the screen.