### PR TITLE
Refactor ProfileButton to a Separate Composable File

### DIFF
--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/Profile.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/Profile.kt
@@ -2,32 +2,26 @@ package com.github.lookupgroup27.lookup.ui.profile
 
 import android.content.res.Configuration
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.compose.rememberNavController
 import com.github.lookupgroup27.lookup.R
 import com.github.lookupgroup27.lookup.ui.navigation.BottomNavigationMenu
 import com.github.lookupgroup27.lookup.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
 import com.github.lookupgroup27.lookup.ui.navigation.Screen
-import com.github.lookupgroup27.lookup.ui.theme.DarkPurple
+import com.github.lookupgroup27.lookup.ui.profile.components.ProfileButton
 
 @Composable
 fun ProfileScreen(navigationActions: NavigationActions) {
@@ -83,32 +77,6 @@ fun ProfileScreen(navigationActions: NavigationActions) {
                 Spacer(modifier = Modifier.height(16.dp))
               }
         }
-      }
-}
-
-@Composable
-fun ProfileButton(text: String, onClick: () -> Unit) {
-  Button(
-      onClick = onClick,
-      colors = ButtonDefaults.buttonColors(containerColor = DarkPurple, contentColor = Color.White),
-      shape = RoundedCornerShape(174.dp),
-      modifier =
-          Modifier.width(
-                  if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE)
-                      200.dp
-                  else 262.dp)
-              .padding(vertical = 8.dp)
-              .border(
-                  width = 1.dp,
-                  color = Color.White.copy(alpha = 0.24f),
-                  shape = RoundedCornerShape(64.dp))
-              .shadow(elevation = 20.dp, shape = RoundedCornerShape(20.dp), clip = true)) {
-        Text(
-            text = text,
-            fontSize = 19.sp,
-            fontWeight = FontWeight.W800,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth())
       }
 }
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/components/ProfileButtons.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/components/ProfileButtons.kt
@@ -1,0 +1,47 @@
+package com.github.lookupgroup27.lookup.ui.profile.components
+
+import android.content.res.Configuration
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.lookupgroup27.lookup.ui.theme.DarkPurple
+
+@Composable
+fun ProfileButton(text: String, onClick: () -> Unit) {
+  Button(
+      onClick = onClick,
+      colors = ButtonDefaults.buttonColors(containerColor = DarkPurple, contentColor = Color.White),
+      shape = RoundedCornerShape(174.dp),
+      modifier =
+          Modifier.width(
+                  if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE)
+                      200.dp
+                  else 262.dp)
+              .padding(vertical = 8.dp)
+              .border(
+                  width = 1.dp,
+                  color = Color.White.copy(alpha = 0.24f),
+                  shape = RoundedCornerShape(64.dp))
+              .shadow(elevation = 20.dp, shape = RoundedCornerShape(20.dp), clip = true)) {
+        Text(
+            text = text,
+            fontSize = 19.sp,
+            fontWeight = FontWeight.W800,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth())
+      }
+}


### PR DESCRIPTION
**Description:** This PR refactors the ProfileButton composable by moving it to its own file to improve code readability and maintainability.

**Changes Made:**

Created a new file for the ProfileButton composable.
Organized the file under ui/profile/components/ to align with best practices for organizing sub-composables used across the same screen.
Rationale: Separating ProfileButton into its own file allows for a modular component structure and facilitates future reusability without cluttering the main screen file.

Linked Issue: Closes #128 