### PR TITLE
Add sign-in check for photo rating in feed

### DIFF
--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/feed/Feed.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/feed/Feed.kt
@@ -96,6 +96,10 @@ fun FeedScreen(
   }
 
   LaunchedEffect(nearbyPosts, profile) {
+    if (userEmail.isEmpty()) {
+      Toast.makeText(context, "Please sign in to rate photos on the feed.", Toast.LENGTH_LONG)
+          .show()
+    }
     nearbyPosts.forEach { post ->
       if (!postRatings.containsKey(post.uid)) {
         // Get saved rating from profile, or initialize with all false


### PR DESCRIPTION
This PR introduces a Toast notification in the FeedScreen to enhance user feedback. When an unauthenticated user (with an empty userEmail) attempts to rate a photo, a Toast message is displayed prompting them to sign in.
**Changes:**
- Added a Toast notification in the FeedScreen that informs users to sign in when trying to rate photos without being authenticated.

**Reason:**
This change improves the user experience by providing immediate feedback when users perform actions that require authentication. It ensures users understand the need to sign in to access certain features.

**Related Issues:**
Closes Issue #149 
