### PR TITLE
Feature/exclude own posts from feed

### DIFF
--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/feed/Feed.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/feed/Feed.kt
@@ -67,9 +67,10 @@ fun FeedScreen(
   val proximityPostFetcher = remember { ProximityPostFetcher(postsViewModel, context) }
 
   var locationPermissionGranted by remember { mutableStateOf(false) }
-  val nearbyPosts by
+  val unfilteredPosts by
       (initialNearbyPosts?.let { mutableStateOf(it) }
           ?: proximityPostFetcher.nearbyPosts.collectAsState())
+  val nearbyPosts = unfilteredPosts.filter { it.username != userEmail }
 
   val postRatings = remember { mutableStateMapOf<String, List<Boolean>>() }
 


### PR DESCRIPTION
**Description:**
This PR updates the feed functionality to enhance the browsing experience by ensuring that posts displayed in the feed are exclusively created by other users, excluding the logged-in user's posts.

**Key Change:**
**Feed Filtering:**
Added logic to filter out posts created by the logged-in user (FirebaseAuth.currentUser.email).
Modified the nearbyPosts property to include only posts from other users.

**Testing :**
Updated test cases to verify the exclusion of the logged-in user's posts.
Ensured posts from other users are still displayed and correctly formatted.

**Acceptance Criteria Fulfilled:**
Posts from the logged-in user are excluded from the feed.
Posts from other users are displayed with their usernames and photos.
UI remains visually consistent and functional.
Verified through test cases.