### PR TITLE
feat: implement login, register, and password reset flows

### DIFF
--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/authentication/SignInKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/authentication/SignInKtTest.kt
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
+import com.github.lookupgroup27.lookup.ui.navigation.Screen
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import org.junit.After
 import org.junit.Before
@@ -76,7 +77,7 @@ class SignInKtTest : TestCase() {
     composeTestRule.waitForIdle()
 
     // Assert that the user is navigated back to the previous screen
-    verify(mockNavigationActions).goBack()
+    verify(mockNavigationActions).navigateTo(Screen.MENU)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/login/LoginKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/login/LoginKtTest.kt
@@ -1,4 +1,85 @@
 package com.github.lookupgroup27.lookup.ui.login
 
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.navigation.NavHostController
+import androidx.test.core.app.ApplicationProvider
+import com.github.lookupgroup27.lookup.model.login.LoginRepository
+import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
+import org.junit.Rule
+import org.junit.Test
+
+class MockLoginRepository : LoginRepository {
+  override suspend fun loginUser(email: String, password: String) {}
+}
+
 class LoginKtTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private fun createMockViewModel(): LoginViewModel {
+    val repository = MockLoginRepository()
+    return LoginViewModel(repository)
+  }
+
+  private fun mockNavigationActions() =
+      NavigationActions(
+          navController = NavHostController(ApplicationProvider.getApplicationContext()))
+
+  @Test
+  fun appLogo_isDisplayed() {
+    composeTestRule.setContent {
+      LoginScreen(viewModel = createMockViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("app_logo").assertIsDisplayed()
+  }
+
+  @Test
+  fun screenTitle_isDisplayed() {
+    composeTestRule.setContent {
+      LoginScreen(viewModel = createMockViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("screen_title").assertIsDisplayed()
+  }
+
+  @Test
+  fun emailField_isDisplayed() {
+    composeTestRule.setContent {
+      LoginScreen(viewModel = createMockViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed()
+  }
+
+  @Test
+  fun passwordField_isDisplayed() {
+    composeTestRule.setContent {
+      LoginScreen(viewModel = createMockViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("password_field").assertIsDisplayed()
+  }
+
+  @Test
+  fun loginButton_isDisplayed() {
+    composeTestRule.setContent {
+      LoginScreen(viewModel = createMockViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("login_button").assertIsDisplayed()
+  }
+
+  @Test
+  fun backButton_isDisplayed() {
+    composeTestRule.setContent {
+      LoginScreen(viewModel = createMockViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("back_button").assertIsDisplayed()
+  }
+
+  @Test
+  fun forgotPasswordButton_isDisplayed() {
+    composeTestRule.setContent {
+      LoginScreen(viewModel = createMockViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("forgot_password_button").assertIsDisplayed()
+  }
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/login/LoginKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/login/LoginKtTest.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.ui.login
+
+class LoginKtTest {
+}

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordResetKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordResetKtTest.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.ui.passwordreset
+
+class PasswordResetKtTest {
+}

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordResetKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordResetKtTest.kt
@@ -1,4 +1,105 @@
 package com.github.lookupgroup27.lookup.ui.passwordreset
 
-class PasswordResetKtTest {
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.navigation.NavHostController
+import androidx.test.core.app.ApplicationProvider
+import com.github.lookupgroup27.lookup.model.passwordreset.PasswordResetRepository
+import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
+import org.junit.Rule
+import org.junit.Test
+
+class MockPasswordResetRepository : PasswordResetRepository {
+  override suspend fun sendPasswordResetEmail(email: String): Result<Unit> {
+
+    return if (email == "success@example.com") {
+      Result.success(Unit)
+    } else {
+
+      Result.failure(Exception("Mock error for testing"))
+    }
+  }
+}
+
+class PasswordResetScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private fun createRealViewModel(): PasswordResetViewModel {
+    val repository = MockPasswordResetRepository()
+    return PasswordResetViewModel(repository)
+  }
+
+  private fun mockNavigationActions() =
+      NavigationActions(
+          navController = NavHostController(ApplicationProvider.getApplicationContext()))
+
+  @Test
+  fun appLogo_isDisplayed() {
+    composeTestRule.setContent {
+      PasswordResetScreen(
+          viewModel = createRealViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("app_logo").assertIsDisplayed()
+  }
+
+  @Test
+  fun screenTitle_isDisplayed() {
+    composeTestRule.setContent {
+      PasswordResetScreen(
+          viewModel = createRealViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("screen_title").assertIsDisplayed()
+  }
+
+  @Test
+  fun emailField_isDisplayed() {
+    composeTestRule.setContent {
+      PasswordResetScreen(
+          viewModel = createRealViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed()
+  }
+
+  @Test
+  fun resetButton_isDisplayed() {
+    composeTestRule.setContent {
+      PasswordResetScreen(
+          viewModel = createRealViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("reset_button").assertIsDisplayed()
+  }
+
+  @Test
+  fun backButton_isDisplayed() {
+    composeTestRule.setContent {
+      PasswordResetScreen(
+          viewModel = createRealViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("back_button").assertIsDisplayed()
+  }
+
+  @Test
+  fun emailField_acceptsInput() {
+    composeTestRule.setContent {
+      PasswordResetScreen(
+          viewModel = createRealViewModel(), navigationActions = mockNavigationActions())
+    }
+
+    composeTestRule.onNodeWithTag("email_field").performTextInput("test@example.com")
+  }
+
+  @Test
+  fun resetButton_triggersResetPassword() {
+    composeTestRule.setContent {
+      PasswordResetScreen(
+          viewModel = createRealViewModel(), navigationActions = mockNavigationActions())
+    }
+
+    composeTestRule.onNodeWithTag("email_field").performTextInput("success@example.com")
+    composeTestRule.onNodeWithTag("reset_button").performClick()
+  }
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/register/RegisterKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/register/RegisterKtTest.kt
@@ -1,4 +1,77 @@
 package com.github.lookupgroup27.lookup.ui.register
 
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.navigation.NavHostController
+import androidx.test.core.app.ApplicationProvider
+import com.github.lookupgroup27.lookup.model.register.RegisterRepository
+import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
+import org.junit.Rule
+import org.junit.Test
+
+class MockRegisterRepository : RegisterRepository {
+  override suspend fun registerUser(email: String, password: String) {}
+}
+
 class RegisterKtTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private fun createMockViewModel(): RegisterViewModel {
+    val repository = MockRegisterRepository()
+    return RegisterViewModel(repository)
+  }
+
+  private fun mockNavigationActions() =
+      NavigationActions(
+          navController = NavHostController(ApplicationProvider.getApplicationContext()))
+
+  @Test
+  fun appLogo_isDisplayed() {
+    composeTestRule.setContent {
+      RegisterScreen(viewModel = createMockViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("app_logo").assertIsDisplayed()
+  }
+
+  @Test
+  fun screenTitle_isDisplayed() {
+    composeTestRule.setContent {
+      RegisterScreen(viewModel = createMockViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("screen_title").assertIsDisplayed()
+  }
+
+  @Test
+  fun emailField_isDisplayed() {
+    composeTestRule.setContent {
+      RegisterScreen(viewModel = createMockViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed()
+  }
+
+  @Test
+  fun passwordField_isDisplayed() {
+    composeTestRule.setContent {
+      RegisterScreen(viewModel = createMockViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("password_field").assertIsDisplayed()
+  }
+
+  @Test
+  fun registerButton_isDisplayed() {
+    composeTestRule.setContent {
+      RegisterScreen(viewModel = createMockViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("register_button").assertIsDisplayed()
+  }
+
+  @Test
+  fun backButton_isDisplayed() {
+    composeTestRule.setContent {
+      RegisterScreen(viewModel = createMockViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("back_button").assertIsDisplayed()
+  }
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/register/RegisterKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/register/RegisterKtTest.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.ui.register
+
+class RegisterKtTest {
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/MainActivity.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/MainActivity.kt
@@ -22,12 +22,16 @@ import com.github.lookupgroup27.lookup.ui.feed.FeedScreen
 import com.github.lookupgroup27.lookup.ui.googlemap.GoogleMapScreen
 import com.github.lookupgroup27.lookup.ui.image.CameraCapture
 import com.github.lookupgroup27.lookup.ui.image.ImageReviewScreen
+import com.github.lookupgroup27.lookup.ui.login.LoginScreen
+import com.github.lookupgroup27.lookup.ui.login.LoginViewModel
 import com.github.lookupgroup27.lookup.ui.map.MapScreen
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
 import com.github.lookupgroup27.lookup.ui.navigation.Route
 import com.github.lookupgroup27.lookup.ui.navigation.Screen
 import com.github.lookupgroup27.lookup.ui.overview.LandingScreen
 import com.github.lookupgroup27.lookup.ui.overview.MenuScreen
+import com.github.lookupgroup27.lookup.ui.passwordreset.PasswordResetScreen
+import com.github.lookupgroup27.lookup.ui.passwordreset.PasswordResetViewModel
 import com.github.lookupgroup27.lookup.ui.post.PostsViewModel
 import com.github.lookupgroup27.lookup.ui.profile.CollectionScreen
 import com.github.lookupgroup27.lookup.ui.profile.CollectionViewModel
@@ -37,6 +41,8 @@ import com.github.lookupgroup27.lookup.ui.profile.ProfileViewModel
 import com.github.lookupgroup27.lookup.ui.quiz.QuizPlayScreen
 import com.github.lookupgroup27.lookup.ui.quiz.QuizScreen
 import com.github.lookupgroup27.lookup.ui.quiz.QuizViewModel
+import com.github.lookupgroup27.lookup.ui.register.RegisterScreen
+import com.github.lookupgroup27.lookup.ui.register.RegisterViewModel
 import com.github.lookupgroup27.lookup.ui.theme.LookUpTheme
 import com.google.firebase.auth.FirebaseAuth
 import java.io.File
@@ -66,6 +72,10 @@ fun LookUpApp() {
   val profileViewModel: ProfileViewModel = viewModel(factory = ProfileViewModel.Factory)
   val collectionViewModel: CollectionViewModel = viewModel(factory = CollectionViewModel.Factory)
   val postsViewModel: PostsViewModel = viewModel(factory = PostsViewModel.Factory)
+  val registerViewModel: RegisterViewModel = viewModel(factory = RegisterViewModel.Factory)
+  val loginViewModel: LoginViewModel = viewModel(factory = LoginViewModel.Factory)
+  val passwordResetViewModel: PasswordResetViewModel =
+      viewModel(factory = PasswordResetViewModel.Factory)
 
   NavHost(navController = navController, startDestination = Route.LANDING) {
     navigation(
@@ -73,6 +83,11 @@ fun LookUpApp() {
         route = Route.AUTH,
     ) {
       composable(Screen.AUTH) { SignInScreen(navigationActions) }
+      composable(Screen.REGISTER) { RegisterScreen(registerViewModel, navigationActions) }
+      composable(Screen.LOGIN) { LoginScreen(loginViewModel, navigationActions) }
+      composable(Screen.PASSWORDRESET) {
+        PasswordResetScreen(passwordResetViewModel, navigationActions)
+      }
     }
     navigation(startDestination = Screen.MAP, route = Route.MAP) {
       composable(Screen.MAP) { MapScreen(navigationActions) }
@@ -126,6 +141,18 @@ fun LookUpApp() {
 
     navigation(startDestination = Screen.FEED, route = Route.FEED) {
       composable(Screen.FEED) { FeedScreen(postsViewModel, navigationActions, profileViewModel) }
+    }
+
+    navigation(startDestination = Screen.REGISTER, route = Route.REGISTER) {
+      composable(Screen.REGISTER) { RegisterScreen(registerViewModel, navigationActions) }
+      composable(Screen.AUTH) { SignInScreen(navigationActions) }
+    }
+
+    navigation(startDestination = Screen.PASSWORDRESET, route = Route.PASSWORDRESET) {
+      composable(Screen.PASSWORDRESET) {
+        PasswordResetScreen(passwordResetViewModel, navigationActions)
+      }
+      composable(Screen.AUTH) { SignInScreen(navigationActions) }
     }
   }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/login/LoginRepository.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/login/LoginRepository.kt
@@ -1,0 +1,5 @@
+package com.github.lookupgroup27.lookup.model.login
+
+interface LoginRepository {
+  suspend fun loginUser(email: String, password: String)
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/login/LoginRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/login/LoginRepositoryFirestore.kt
@@ -1,4 +1,12 @@
 package com.github.lookupgroup27.lookup.model.login
 
-class LoginRepositoryFirestore {
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.tasks.await
+
+class LoginRepositoryFirestore(private val auth: FirebaseAuth = FirebaseAuth.getInstance()) :
+    LoginRepository {
+
+  override suspend fun loginUser(email: String, password: String) {
+    auth.signInWithEmailAndPassword(email, password).await()
+  }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/login/LoginRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/login/LoginRepositoryFirestore.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.model.login
+
+class LoginRepositoryFirestore {
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/login/LoginState.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/login/LoginState.kt
@@ -1,4 +1,3 @@
 package com.github.lookupgroup27.lookup.model.login
 
-class LoginState {
-}
+data class LoginState(val email: String = "", val password: String = "")

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/login/LoginState.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/login/LoginState.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.model.login
+
+class LoginState {
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/passwordreset/PasswordResetRepository.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/passwordreset/PasswordResetRepository.kt
@@ -1,4 +1,5 @@
 package com.github.lookupgroup27.lookup.model.passwordreset
 
-class PasswordResetRepository {
+interface PasswordResetRepository {
+  suspend fun sendPasswordResetEmail(email: String): Result<Unit>
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/passwordreset/PasswordResetRepository.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/passwordreset/PasswordResetRepository.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.model.passwordreset
+
+class PasswordResetRepository {
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/passwordreset/PasswordResetRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/passwordreset/PasswordResetRepositoryFirestore.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.model.passwordreset
+
+class PasswordResetRepository {
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/passwordreset/PasswordResetRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/passwordreset/PasswordResetRepositoryFirestore.kt
@@ -1,4 +1,17 @@
 package com.github.lookupgroup27.lookup.model.passwordreset
 
-class PasswordResetRepository {
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.tasks.await
+
+class PasswordResetRepositoryFirestore(
+    private val auth: FirebaseAuth = FirebaseAuth.getInstance()
+) : PasswordResetRepository {
+  override suspend fun sendPasswordResetEmail(email: String): Result<Unit> {
+    return try {
+      auth.sendPasswordResetEmail(email).await()
+      Result.success(Unit)
+    } catch (e: Exception) {
+      Result.failure(e)
+    }
+  }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/passwordreset/PasswordResetState.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/passwordreset/PasswordResetState.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.model.passwordreset
+
+class PasswordResetState {
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/passwordreset/PasswordResetState.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/passwordreset/PasswordResetState.kt
@@ -1,4 +1,8 @@
 package com.github.lookupgroup27.lookup.model.passwordreset
 
-class PasswordResetState {
-}
+data class PasswordResetState(
+    val email: String = "",
+    val isLoading: Boolean = false,
+    val isSuccess: Boolean = false,
+    val errorMessage: String? = null
+)

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterRepository.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterRepository.kt
@@ -1,4 +1,5 @@
 package com.github.lookupgroup27.lookup.model.register
 
-class RegisterRepository {
+interface RegisterRepository {
+  suspend fun registerUser(email: String, password: String)
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterRepository.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterRepository.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.model.register
+
+class RegisterRepository {
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterRepositoryFirestore.kt
@@ -1,0 +1,13 @@
+package com.github.lookupgroup27.lookup.data.repository
+
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.tasks.await
+
+class RegisterRepository {
+
+    private val auth: FirebaseAuth = FirebaseAuth.getInstance()
+
+    suspend fun registerUser(email: String, password: String) {
+        auth.createUserWithEmailAndPassword(email, password).await()
+    }
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterRepositoryFirestore.kt
@@ -1,13 +1,12 @@
-package com.github.lookupgroup27.lookup.data.repository
+package com.github.lookupgroup27.lookup.model.register
 
 import com.google.firebase.auth.FirebaseAuth
 import kotlinx.coroutines.tasks.await
 
-class RegisterRepository {
+class RegisterRepositoryFirestore(private val auth: FirebaseAuth = FirebaseAuth.getInstance()) :
+    RegisterRepository {
 
-    private val auth: FirebaseAuth = FirebaseAuth.getInstance()
-
-    suspend fun registerUser(email: String, password: String) {
-        auth.createUserWithEmailAndPassword(email, password).await()
-    }
+  override suspend fun registerUser(email: String, password: String) {
+    auth.createUserWithEmailAndPassword(email, password).await()
+  }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterState.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterState.kt
@@ -1,4 +1,3 @@
 package com.github.lookupgroup27.lookup.model.register
 
-class RegisterState {
-}
+data class RegisterState(val email: String = "", val password: String = "")

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterState.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterState.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.model.register
+
+class RegisterState {
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/authentication/SignIn.kt
@@ -67,7 +67,7 @@ fun SignInScreen(navigationActions: NavigationActions) {
   val token = stringResource(R.string.default_web_client_id)
 
   Scaffold(
-      modifier = Modifier.fillMaxSize(),
+      modifier = Modifier.fillMaxSize().testTag("auth_screen"),
       containerColor = Color.Black,
       topBar = {
         TopAppBar(
@@ -87,10 +87,7 @@ fun SignInScreen(navigationActions: NavigationActions) {
       content = { padding ->
         Column(
             modifier =
-                Modifier.fillMaxSize()
-                    .padding(padding)
-                    .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 24.dp, vertical = 32.dp),
+                Modifier.fillMaxSize().padding(padding).verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center) {
               Spacer(modifier = Modifier.height(16.dp))
@@ -103,6 +100,7 @@ fun SignInScreen(navigationActions: NavigationActions) {
               Spacer(modifier = Modifier.height(16.dp))
 
               Text(
+                  modifier = Modifier.testTag("loginTitle"),
                   text = "Welcome to the Cosmos",
                   style =
                       MaterialTheme.typography.headlineMedium.copy(

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/authentication/SignIn.kt
@@ -2,7 +2,6 @@ package com.github.lookupgroup27.lookup.ui.authentication
 
 import android.content.Intent
 import android.content.res.Configuration
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -24,6 +23,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.*
@@ -60,25 +60,21 @@ fun SignInScreen(navigationActions: NavigationActions) {
   val launcher =
       rememberFirebaseAuthLauncher(
           onAuthComplete = { result ->
-            Log.d("SignInScreen", "User signed in: ${result.user?.displayName}")
             Toast.makeText(context, "Login successful!", Toast.LENGTH_LONG).show()
             navigationActions.navigateTo(Screen.PROFILE)
           },
-          onAuthError = {
-            Log.e("SignInScreen", "Failed to sign in: ${it.statusCode}")
-            Toast.makeText(context, "Login Failed!", Toast.LENGTH_LONG).show()
-          })
+          onAuthError = { Toast.makeText(context, "Login Failed!", Toast.LENGTH_LONG).show() })
   val token = stringResource(R.string.default_web_client_id)
 
   Scaffold(
-      modifier = Modifier.fillMaxSize().testTag("auth_screen"),
+      modifier = Modifier.fillMaxSize(),
       containerColor = Color.Black,
       topBar = {
         TopAppBar(
             title = {},
             navigationIcon = {
               IconButton(
-                  onClick = { navigationActions.goBack() },
+                  onClick = { navigationActions.navigateTo(Screen.MENU) },
                   modifier = Modifier.testTag("go_back_button_signin")) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -93,8 +89,8 @@ fun SignInScreen(navigationActions: NavigationActions) {
             modifier =
                 Modifier.fillMaxSize()
                     .padding(padding)
-                    .verticalScroll(
-                        rememberScrollState()), // Enable vertical scrolling in all orientations
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 24.dp, vertical = 32.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center) {
               Spacer(modifier = Modifier.height(16.dp))
@@ -102,22 +98,24 @@ fun SignInScreen(navigationActions: NavigationActions) {
               Image(
                   painter = painterResource(id = R.drawable.app_logo),
                   contentDescription = "App Logo",
-                  modifier = Modifier.size(250.dp))
+                  modifier = Modifier.size(150.dp))
 
               Spacer(modifier = Modifier.height(16.dp))
 
               Text(
-                  modifier = Modifier.testTag("loginTitle"),
                   text = "Welcome to the Cosmos",
                   style =
                       MaterialTheme.typography.headlineMedium.copy(
-                          fontSize = 42.sp, lineHeight = 50.sp, letterSpacing = 1.5.sp),
-                  fontWeight = FontWeight.SemiBold,
-                  textAlign = TextAlign.Center,
-                  color = Color(0xFF8A9BB7))
+                          fontSize = 42.sp,
+                          lineHeight = 50.sp,
+                          letterSpacing = 1.5.sp,
+                          fontWeight = FontWeight.SemiBold,
+                          color = Color.White),
+                  textAlign = TextAlign.Center)
 
               Spacer(modifier = Modifier.height(48.dp))
 
+              // Google Sign-In Button (Unchanged)
               GoogleSignInButton(
                   onSignInClick = {
                     val gso =
@@ -128,6 +126,39 @@ fun SignInScreen(navigationActions: NavigationActions) {
                     val googleSignInClient = GoogleSignIn.getClient(context, gso)
                     launcher.launch(googleSignInClient.signInIntent)
                   })
+
+              Spacer(modifier = Modifier.height(16.dp))
+
+              // Register Button
+              Button(
+                  onClick = { navigationActions.navigateTo(Screen.REGISTER) },
+                  modifier = Modifier.fillMaxWidth(),
+                  colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF1A1A2E))) {
+                    Text("Register", color = Color.White)
+                  }
+
+              Spacer(modifier = Modifier.height(16.dp))
+
+              // Login Button
+              Button(
+                  onClick = { navigationActions.navigateTo(Screen.LOGIN) },
+                  modifier = Modifier.fillMaxWidth(),
+                  colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF1A1A2E))) {
+                    Text("Login", color = Color.White)
+                  }
+
+              Spacer(modifier = Modifier.height(16.dp))
+
+              // Forgot Password Button
+              TextButton(
+                  onClick = { navigationActions.navigateTo(Screen.PASSWORDRESET) },
+                  modifier = Modifier.align(Alignment.CenterHorizontally)) {
+                    Text(
+                        text = "Forgot Password?",
+                        style =
+                            MaterialTheme.typography.bodyLarge.copy(
+                                color = MaterialTheme.colorScheme.primary))
+                  }
             }
       })
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/login/Login.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/login/Login.kt
@@ -1,4 +1,140 @@
 package com.github.lookupgroup27.lookup.ui.login
 
-class Login {
+import android.widget.Toast
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import com.github.lookupgroup27.lookup.R
+import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
+import com.github.lookupgroup27.lookup.ui.navigation.Screen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LoginScreen(viewModel: LoginViewModel, navigationActions: NavigationActions) {
+  val context = LocalContext.current
+  val uiState by viewModel.uiState.collectAsState()
+
+  Scaffold(
+      modifier = Modifier.fillMaxSize(),
+      containerColor = Color.Black,
+      topBar = {
+        TopAppBar(
+            title = {},
+            navigationIcon = {
+              IconButton(
+                  onClick = {
+                    viewModel.clearFields()
+                    navigationActions.navigateTo(Screen.AUTH)
+                  },
+                  modifier = Modifier.testTag("back_button")) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Go Back",
+                        tint = Color.White)
+                  }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Black))
+      },
+      content = { padding ->
+        Column(
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(padding)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 24.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center) {
+              Image(
+                  painter = painterResource(id = R.drawable.app_logo),
+                  contentDescription = "App Logo",
+                  modifier = Modifier.size(150.dp).padding(bottom = 16.dp).testTag("app_logo"))
+
+              Text(
+                  text = "Log In to Your Account",
+                  style =
+                      MaterialTheme.typography.headlineMedium.copy(
+                          fontWeight = FontWeight.Bold, color = Color.White),
+                  modifier = Modifier.padding(bottom = 24.dp).testTag("screen_title"))
+
+              OutlinedTextField(
+                  value = uiState.email,
+                  onValueChange = { viewModel.onEmailChanged(it) },
+                  label = { Text("Email", color = Color.White) },
+                  modifier = Modifier.fillMaxWidth().testTag("email_field"),
+                  textStyle = MaterialTheme.typography.bodyLarge.copy(color = Color.White),
+                  colors =
+                      TextFieldDefaults.outlinedTextFieldColors(
+                          focusedLabelColor = Color.White,
+                          unfocusedLabelColor = Color.Gray,
+                          focusedBorderColor = Color.White,
+                          unfocusedBorderColor = Color.Gray,
+                          cursorColor = Color.White))
+
+              Spacer(modifier = Modifier.height(16.dp))
+
+              OutlinedTextField(
+                  value = uiState.password,
+                  onValueChange = { viewModel.onPasswordChanged(it) },
+                  label = { Text("Password", color = Color.White) },
+                  visualTransformation = PasswordVisualTransformation(),
+                  modifier = Modifier.fillMaxWidth().testTag("password_field"),
+                  textStyle = MaterialTheme.typography.bodyLarge.copy(color = Color.White),
+                  colors =
+                      TextFieldDefaults.outlinedTextFieldColors(
+                          focusedLabelColor = Color.White,
+                          unfocusedLabelColor = Color.Gray,
+                          focusedBorderColor = Color.White,
+                          unfocusedBorderColor = Color.Gray,
+                          cursorColor = Color.White))
+
+              Spacer(modifier = Modifier.height(24.dp))
+
+              Button(
+                  onClick = {
+                    viewModel.loginUser(
+                        onSuccess = {
+                          Toast.makeText(context, "Login successful!", Toast.LENGTH_LONG).show()
+                          viewModel.clearFields()
+                          navigationActions.navigateTo(Screen.PROFILE)
+                        },
+                        onError = { error ->
+                          Toast.makeText(context, error, Toast.LENGTH_LONG).show()
+                        })
+                  },
+                  modifier = Modifier.fillMaxWidth().testTag("login_button"),
+                  colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF1A1A2E))) {
+                    Text("Login", color = Color.White)
+                  }
+
+              Spacer(modifier = Modifier.height(16.dp))
+
+              TextButton(
+                  onClick = { navigationActions.navigateTo(Screen.PASSWORDRESET) },
+                  modifier =
+                      Modifier.align(Alignment.CenterHorizontally)
+                          .testTag("forgot_password_button")) {
+                    Text(
+                        text = "Forgot Password?",
+                        style =
+                            MaterialTheme.typography.bodyLarge.copy(
+                                color = MaterialTheme.colorScheme.primary))
+                  }
+            }
+      })
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/login/Login.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/login/Login.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.ui.login
+
+class Login {
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/login/LoginViewModel.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.ui.login
+
+class LoginViewModel {
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/login/LoginViewModel.kt
@@ -1,4 +1,59 @@
 package com.github.lookupgroup27.lookup.ui.login
 
-class LoginViewModel {
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.github.lookupgroup27.lookup.model.login.LoginRepository
+import com.github.lookupgroup27.lookup.model.login.LoginRepositoryFirestore
+import com.github.lookupgroup27.lookup.model.login.LoginState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class LoginViewModel(private val repository: LoginRepository) : ViewModel() {
+
+  private val _uiState = MutableStateFlow(LoginState())
+  val uiState: StateFlow<LoginState> = _uiState
+
+  fun onEmailChanged(email: String) {
+    _uiState.update { it.copy(email = email) }
+  }
+
+  fun onPasswordChanged(password: String) {
+    _uiState.update { it.copy(password = password) }
+  }
+
+  fun clearFields() {
+    _uiState.value = _uiState.value.copy(email = "", password = "")
+  }
+
+  fun loginUser(onSuccess: () -> Unit, onError: (String) -> Unit) {
+    val email = _uiState.value.email
+    val password = _uiState.value.password
+
+    if (email.isBlank() || password.isBlank()) {
+      onError("Email and password cannot be empty")
+      return
+    }
+
+    viewModelScope.launch {
+      try {
+        repository.loginUser(email, password)
+        onSuccess()
+      } catch (e: Exception) {
+        onError(e.localizedMessage ?: "Login failed")
+      }
+    }
+  }
+
+  companion object {
+    val Factory: ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+          @Suppress("UNCHECKED_CAST")
+          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return LoginViewModel(LoginRepositoryFirestore()) as T
+          }
+        }
+  }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/NavigationActions.kt
@@ -23,6 +23,9 @@ object Route {
   const val TAKE_IMAGE = "TakeImage"
   const val IMAGE_REVIEW = "ImageReview"
   const val FEED = "Feed"
+  const val LOGIN = "Login"
+  const val REGISTER = "Register"
+  const val PASSWORDRESET = "PasswordReset"
 }
 
 object Screen {
@@ -40,6 +43,9 @@ object Screen {
   const val TAKE_IMAGE = "Take Image"
   const val IMAGE_REVIEW = "Image Review Screen"
   const val FEED = "Feed Screen"
+  const val LOGIN = "Login Screen"
+  const val REGISTER = "Register Screen"
+  const val PASSWORDRESET = "PasswordReset Screen"
 }
 
 data class TopLevelDestination(val route: String, val icon: ImageVector, val textId: String)

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordReset.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordReset.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.ui.passwordreset
+
+class PasswordReset {
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordReset.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordReset.kt
@@ -1,4 +1,123 @@
 package com.github.lookupgroup27.lookup.ui.passwordreset
 
-class PasswordReset {
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.github.lookupgroup27.lookup.R
+import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PasswordResetScreen(viewModel: PasswordResetViewModel, navigationActions: NavigationActions) {
+  val uiState by viewModel.uiState.collectAsState()
+
+  LaunchedEffect(Unit) { viewModel.resetUiState() }
+
+  Scaffold(
+      modifier = Modifier.fillMaxSize(),
+      containerColor = Color.Black,
+      topBar = {
+        TopAppBar(
+            title = {},
+            navigationIcon = {
+              IconButton(
+                  onClick = {
+                    viewModel.clearFields()
+                    navigationActions.goBack()
+                  },
+                  modifier = Modifier.testTag("back_button")) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Go Back",
+                        tint = Color.White)
+                  }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Black))
+      },
+      content = { padding ->
+        Column(
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(padding)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 24.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center) {
+              Image(
+                  painter = painterResource(id = R.drawable.app_logo),
+                  contentDescription = "App Logo",
+                  modifier = Modifier.size(150.dp).padding(bottom = 16.dp).testTag("app_logo"))
+
+              Text(
+                  text = "Reset Your Password",
+                  style =
+                      MaterialTheme.typography.headlineMedium.copy(
+                          fontWeight = FontWeight.Bold, color = Color.White),
+                  modifier = Modifier.padding(bottom = 24.dp).testTag("screen_title"))
+
+              OutlinedTextField(
+                  value = uiState.email,
+                  onValueChange = { viewModel.onEmailChanged(it) },
+                  label = { Text("Email", color = Color.White) },
+                  modifier = Modifier.fillMaxWidth().testTag("email_field"),
+                  textStyle = MaterialTheme.typography.bodyLarge.copy(color = Color.White),
+                  keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Email),
+                  colors =
+                      TextFieldDefaults.outlinedTextFieldColors(
+                          focusedLabelColor = Color.White,
+                          unfocusedLabelColor = Color.Gray,
+                          focusedBorderColor = Color.White,
+                          unfocusedBorderColor = Color.Gray,
+                          cursorColor = Color.White))
+
+              Spacer(modifier = Modifier.height(24.dp))
+
+              Button(
+                  onClick = { viewModel.resetPassword() },
+                  modifier = Modifier.fillMaxWidth().testTag("reset_button"),
+                  colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF1A1A2E))) {
+                    Text("Send Reset Email", color = Color.White)
+                  }
+
+              Spacer(modifier = Modifier.height(16.dp))
+
+              when {
+                uiState.isLoading -> {
+                  CircularProgressIndicator(
+                      color = Color.White, modifier = Modifier.testTag("loading_indicator"))
+                }
+                uiState.errorMessage != null -> {
+                  Text(
+                      text = uiState.errorMessage!!,
+                      color = Color.Red,
+                      style = MaterialTheme.typography.bodyLarge,
+                      modifier = Modifier.testTag("error_message"))
+                }
+                uiState.isSuccess -> {
+                  Text(
+                      text = "Password reset email sent successfully!",
+                      color = Color.Green,
+                      style = MaterialTheme.typography.bodyLarge,
+                      modifier = Modifier.testTag("success_message"))
+                }
+              }
+            }
+      })
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordResetViewModel.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordResetViewModel.kt
@@ -1,4 +1,61 @@
 package com.github.lookupgroup27.lookup.ui.passwordreset
 
-class PasswordResetViewModel {
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.github.lookupgroup27.lookup.model.passwordreset.PasswordResetRepository
+import com.github.lookupgroup27.lookup.model.passwordreset.PasswordResetRepositoryFirestore
+import com.github.lookupgroup27.lookup.model.passwordreset.PasswordResetState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class PasswordResetViewModel(private val repository: PasswordResetRepository) : ViewModel() {
+
+  private val _uiState = MutableStateFlow(PasswordResetState())
+  val uiState: StateFlow<PasswordResetState> = _uiState
+
+  fun onEmailChanged(email: String) {
+    _uiState.update { it.copy(email = email) }
+  }
+
+  fun clearFields() {
+    _uiState.update { it.copy(email = "") }
+  }
+
+  fun resetUiState() {
+    _uiState.value = PasswordResetState()
+  }
+
+  fun resetPassword() {
+    val email = _uiState.value.email
+
+    if (email.isBlank()) {
+      _uiState.update { it.copy(errorMessage = "Email cannot be empty") }
+      return
+    }
+
+    viewModelScope.launch {
+      _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+      val result = repository.sendPasswordResetEmail(email)
+      result
+          .onSuccess { _uiState.update { it.copy(isSuccess = true, isLoading = false) } }
+          .onFailure { e ->
+            _uiState.update {
+              it.copy(isLoading = false, errorMessage = e.localizedMessage ?: "Unknown error")
+            }
+          }
+    }
+  }
+
+  companion object {
+    val Factory: ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+          @Suppress("UNCHECKED_CAST")
+          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return PasswordResetViewModel(PasswordResetRepositoryFirestore()) as T
+          }
+        }
+  }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordResetViewModel.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordResetViewModel.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.ui.passwordreset
+
+class PasswordResetViewModel {
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/register/Register.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/register/Register.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.ui.register
+
+class Register {
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/register/Register.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/register/Register.kt
@@ -1,4 +1,130 @@
 package com.github.lookupgroup27.lookup.ui.register
 
-class Register {
+import android.widget.Toast
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import com.github.lookupgroup27.lookup.R
+import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
+import com.github.lookupgroup27.lookup.ui.navigation.Screen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RegisterScreen(viewModel: RegisterViewModel, navigationActions: NavigationActions) {
+  val context = LocalContext.current
+  val uiState by viewModel.uiState.collectAsState()
+
+  Scaffold(
+      modifier = Modifier.fillMaxSize(),
+      containerColor = Color.Black,
+      topBar = {
+        TopAppBar(
+            title = {},
+            navigationIcon = {
+              IconButton(
+                  onClick = {
+                    viewModel.clearFields()
+                    navigationActions.navigateTo(Screen.AUTH)
+                  },
+                  modifier = Modifier.testTag("back_button")) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Go Back",
+                        tint = Color.White)
+                  }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Black))
+      },
+      content = { padding ->
+        Column(
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(padding)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 24.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center) {
+              Image(
+                  painter = painterResource(id = R.drawable.app_logo),
+                  contentDescription = "App Logo",
+                  modifier = Modifier.size(150.dp).padding(bottom = 16.dp).testTag("app_logo"))
+
+              Text(
+                  text = "Create Your Account",
+                  style =
+                      MaterialTheme.typography.headlineMedium.copy(
+                          fontWeight = FontWeight.Bold, color = Color.White),
+                  modifier = Modifier.padding(bottom = 24.dp).testTag("screen_title"))
+
+              OutlinedTextField(
+                  value = uiState.email,
+                  onValueChange = { viewModel.onEmailChanged(it) },
+                  label = { Text("Email", color = Color.White) },
+                  modifier = Modifier.fillMaxWidth().testTag("email_field"),
+                  textStyle = MaterialTheme.typography.bodyLarge.copy(color = Color.White),
+                  colors =
+                      TextFieldDefaults.outlinedTextFieldColors(
+                          focusedTextColor = Color.White,
+                          unfocusedTextColor = Color.White,
+                          focusedLabelColor = Color.White,
+                          unfocusedLabelColor = Color.Gray,
+                          focusedBorderColor = Color.White,
+                          unfocusedBorderColor = Color.Gray,
+                          cursorColor = Color.White))
+
+              Spacer(modifier = Modifier.height(16.dp))
+
+              OutlinedTextField(
+                  value = uiState.password,
+                  onValueChange = { viewModel.onPasswordChanged(it) },
+                  label = { Text("Password", color = Color.White) },
+                  visualTransformation = PasswordVisualTransformation(),
+                  modifier = Modifier.fillMaxWidth().testTag("password_field"),
+                  textStyle = MaterialTheme.typography.bodyLarge.copy(color = Color.White),
+                  colors =
+                      TextFieldDefaults.outlinedTextFieldColors(
+                          focusedTextColor = Color.White,
+                          unfocusedTextColor = Color.White,
+                          focusedLabelColor = Color.White,
+                          unfocusedLabelColor = Color.Gray,
+                          focusedBorderColor = Color.White,
+                          unfocusedBorderColor = Color.Gray,
+                          cursorColor = Color.White))
+
+              Spacer(modifier = Modifier.height(24.dp))
+
+              Button(
+                  onClick = {
+                    viewModel.registerUser(
+                        onSuccess = {
+                          Toast.makeText(context, "Registration successful!", Toast.LENGTH_LONG)
+                              .show()
+                          navigationActions.navigateTo(Screen.AUTH)
+                        },
+                        onError = { error ->
+                          Toast.makeText(context, error, Toast.LENGTH_LONG).show()
+                        })
+                  },
+                  modifier = Modifier.fillMaxWidth().testTag("register_button"),
+                  colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF1A1A2E))) {
+                    Text("Register", color = Color.White)
+                  }
+            }
+      })
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/register/RegisterViewModel.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.ui.register
+
+class RegisterViewModel {
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/register/RegisterViewModel.kt
@@ -1,4 +1,59 @@
 package com.github.lookupgroup27.lookup.ui.register
 
-class RegisterViewModel {
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.github.lookupgroup27.lookup.model.register.RegisterRepository
+import com.github.lookupgroup27.lookup.model.register.RegisterRepositoryFirestore
+import com.github.lookupgroup27.lookup.model.register.RegisterState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class RegisterViewModel(private val repository: RegisterRepository) : ViewModel() {
+
+  private val _uiState = MutableStateFlow(RegisterState())
+  val uiState: StateFlow<RegisterState> = _uiState
+
+  companion object {
+    val Factory: ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+          @Suppress("UNCHECKED_CAST")
+          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return RegisterViewModel(RegisterRepositoryFirestore()) as T
+          }
+        }
+  }
+
+  fun onEmailChanged(email: String) {
+    _uiState.update { it.copy(email = email) }
+  }
+
+  fun onPasswordChanged(password: String) {
+    _uiState.update { it.copy(password = password) }
+  }
+
+  fun clearFields() {
+    _uiState.value = _uiState.value.copy(email = "", password = "")
+  }
+
+  fun registerUser(onSuccess: () -> Unit, onError: (String) -> Unit) {
+    val email = _uiState.value.email
+    val password = _uiState.value.password
+
+    if (email.isBlank() || password.isBlank()) {
+      onError("Email and password cannot be empty")
+      return
+    }
+
+    viewModelScope.launch {
+      try {
+        repository.registerUser(email, password)
+        onSuccess()
+      } catch (e: Exception) {
+        onError(e.localizedMessage ?: "Registration failed")
+      }
+    }
+  }
 }

--- a/app/src/test/java/com/github/lookupgroup27/lookup/model/login/LoginRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/model/login/LoginRepositoryFirestoreTest.kt
@@ -1,4 +1,85 @@
 package com.github.lookupgroup27.lookup.model.login
 
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.FirebaseApp
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
 class LoginRepositoryFirestoreTest {
+
+  private lateinit var repository: LoginRepositoryFirestore
+  private lateinit var mockAuth: FirebaseAuth
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+
+    if (FirebaseApp.getApps(androidx.test.core.app.ApplicationProvider.getApplicationContext())
+        .isEmpty()) {
+      FirebaseApp.initializeApp(androidx.test.core.app.ApplicationProvider.getApplicationContext())
+    }
+
+    mockAuth = mock(FirebaseAuth::class.java)
+
+    repository = LoginRepositoryFirestore(mockAuth)
+  }
+
+  @Test
+  fun `loginUser succeeds with valid credentials`() = runBlocking {
+    `when`(mockAuth.signInWithEmailAndPassword("test@example.com", "password123"))
+        .thenReturn(Tasks.forResult(mock()))
+
+    try {
+      repository.loginUser("test@example.com", "password123")
+      assertTrue(true)
+    } catch (e: Exception) {
+      assert(false)
+    }
+  }
+
+  @Test
+  fun `loginUser fails with invalid credentials`() = runBlocking {
+    val exception = Exception("Invalid credentials")
+    `when`(mockAuth.signInWithEmailAndPassword("test@example.com", "wrongpassword"))
+        .thenReturn(Tasks.forException(exception))
+
+    try {
+      repository.loginUser("test@example.com", "wrongpassword")
+      assert(false)
+    } catch (e: Exception) {
+      assert(e.message == "Invalid credentials")
+    }
+  }
+
+  @Test
+  fun `loginUser fails when FirebaseAuth throws exception`() = runBlocking {
+    val exception = Exception("Firebase error")
+    `when`(mockAuth.signInWithEmailAndPassword(anyString(), anyString()))
+        .thenReturn(Tasks.forException(exception))
+
+    try {
+      repository.loginUser("test@example.com", "password123")
+      assert(false)
+    } catch (e: Exception) {
+      assert(e.message == "Firebase error")
+    }
+  }
+
+  @Test
+  fun `loginUser returns exception for empty email or password`() = runBlocking {
+    try {
+      repository.loginUser("", "")
+      assert(false)
+    } catch (e: Exception) {
+      assert(true)
+    }
+  }
 }

--- a/app/src/test/java/com/github/lookupgroup27/lookup/model/login/LoginRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/model/login/LoginRepositoryFirestoreTest.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.model.login
+
+class LoginRepositoryFirestoreTest {
+}

--- a/app/src/test/java/com/github/lookupgroup27/lookup/model/passwordreset/PasswordResetRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/model/passwordreset/PasswordResetRepositoryFirestoreTest.kt
@@ -1,4 +1,71 @@
 package com.github.lookupgroup27.lookup.model.passwordreset
 
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.FirebaseApp
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
 class PasswordResetRepositoryFirestoreTest {
+
+  private lateinit var repository: PasswordResetRepositoryFirestore
+  private lateinit var mockAuth: FirebaseAuth
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+
+    if (FirebaseApp.getApps(androidx.test.core.app.ApplicationProvider.getApplicationContext())
+        .isEmpty()) {
+      FirebaseApp.initializeApp(androidx.test.core.app.ApplicationProvider.getApplicationContext())
+    }
+
+    mockAuth = mock(FirebaseAuth::class.java)
+
+    repository =
+        PasswordResetRepositoryFirestore().apply {
+          val field = PasswordResetRepositoryFirestore::class.java.getDeclaredField("auth")
+          field.isAccessible = true
+          field.set(this, mockAuth)
+        }
+  }
+
+  @Test
+  fun `sendPasswordResetEmail succeeds with valid email`() = runBlocking {
+    `when`(mockAuth.sendPasswordResetEmail("test@example.com")).thenReturn(Tasks.forResult(null))
+
+    val result = repository.sendPasswordResetEmail("test@example.com")
+
+    assertTrue(result.isSuccess)
+  }
+
+  @Test
+  fun `sendPasswordResetEmail fails with invalid email`() = runBlocking {
+    val exception = Exception("Invalid email format")
+    `when`(mockAuth.sendPasswordResetEmail("invalid-email"))
+        .thenReturn(Tasks.forException(exception))
+
+    val result = repository.sendPasswordResetEmail("invalid-email")
+
+    assertTrue(result.isFailure)
+    assert(result.exceptionOrNull()?.message == "Invalid email format")
+  }
+
+  @Test
+  fun `sendPasswordResetEmail fails when FirebaseAuth throws an exception`() = runBlocking {
+    val exception = Exception("Firebase error")
+    `when`(mockAuth.sendPasswordResetEmail(anyString())).thenReturn(Tasks.forException(exception))
+
+    val result = repository.sendPasswordResetEmail("test@example.com")
+
+    assertTrue(result.isFailure)
+    assert(result.exceptionOrNull()?.message == "Firebase error")
+  }
 }

--- a/app/src/test/java/com/github/lookupgroup27/lookup/model/passwordreset/PasswordResetRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/model/passwordreset/PasswordResetRepositoryFirestoreTest.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.model.passwordreset
+
+class PasswordResetRepositoryFirestoreTest {
+}

--- a/app/src/test/java/com/github/lookupgroup27/lookup/model/register/RegisterRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/model/register/RegisterRepositoryFirestoreTest.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.model.register
+
+class RegisterRepositoryFirestoreTest {
+}

--- a/app/src/test/java/com/github/lookupgroup27/lookup/model/register/RegisterRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/model/register/RegisterRepositoryFirestoreTest.kt
@@ -1,4 +1,87 @@
 package com.github.lookupgroup27.lookup.model.register
 
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.FirebaseApp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
 class RegisterRepositoryFirestoreTest {
+
+  private lateinit var repository: RegisterRepositoryFirestore
+  private lateinit var mockAuth: FirebaseAuth
+  private lateinit var mockUser: FirebaseUser
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+
+    if (FirebaseApp.getApps(androidx.test.core.app.ApplicationProvider.getApplicationContext())
+        .isEmpty()) {
+      FirebaseApp.initializeApp(androidx.test.core.app.ApplicationProvider.getApplicationContext())
+    }
+
+    mockAuth = mock(FirebaseAuth::class.java)
+
+    repository = RegisterRepositoryFirestore(mockAuth)
+  }
+
+  @Test
+  fun `registerUser succeeds with valid credentials`() = runBlocking {
+    `when`(mockAuth.createUserWithEmailAndPassword("test@example.com", "password123"))
+        .thenReturn(Tasks.forResult(mock()))
+
+    try {
+      repository.registerUser("test@example.com", "password123")
+      assertTrue(true)
+    } catch (e: Exception) {
+      assert(false)
+    }
+  }
+
+  @Test
+  fun `registerUser fails with invalid credentials`() = runBlocking {
+    val exception = Exception("Invalid email format")
+    `when`(mockAuth.createUserWithEmailAndPassword("invalid-email", "password123"))
+        .thenReturn(Tasks.forException(exception))
+
+    try {
+      repository.registerUser("invalid-email", "password123")
+      assert(false)
+    } catch (e: Exception) {
+      assert(e.message == "Invalid email format")
+    }
+  }
+
+  @Test
+  fun `registerUser fails when FirebaseAuth throws exception`() = runBlocking {
+    val exception = Exception("Firebase error")
+    `when`(mockAuth.createUserWithEmailAndPassword(anyString(), anyString()))
+        .thenReturn(Tasks.forException(exception))
+
+    try {
+      repository.registerUser("test@example.com", "password123")
+      assert(false)
+    } catch (e: Exception) {
+      assert(e.message == "Firebase error")
+    }
+  }
+
+  @Test
+  fun `registerUser returns exception for empty email or password`() = runBlocking {
+    try {
+      repository.registerUser("", "")
+      assert(false)
+    } catch (e: Exception) {
+      assert(true)
+    }
+  }
 }

--- a/app/src/test/java/com/github/lookupgroup27/lookup/ui/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/ui/login/LoginViewModelTest.kt
@@ -1,4 +1,79 @@
 package com.github.lookupgroup27.lookup.ui.login
 
+import com.github.lookupgroup27.lookup.model.login.LoginRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
 class LoginViewModelTest {
+
+  private lateinit var viewModel: LoginViewModel
+  private lateinit var mockRepository: LoginRepository
+
+  @Before
+  fun setUp() {
+    mockRepository = mock()
+    viewModel = LoginViewModel(mockRepository)
+  }
+
+  @Test
+  fun `onEmailChanged updates email in uiState`() = runTest {
+    viewModel.onEmailChanged("test@example.com")
+
+    val currentState = viewModel.uiState.first()
+    assertEquals("test@example.com", currentState.email)
+  }
+
+  @Test
+  fun `onPasswordChanged updates password in uiState`() = runTest {
+    viewModel.onPasswordChanged("password123")
+
+    val currentState = viewModel.uiState.first()
+    assertEquals("password123", currentState.password)
+  }
+
+  @Test
+  fun `clearFields resets email and password in uiState`() = runTest {
+    viewModel.onEmailChanged("test@example.com")
+    viewModel.onPasswordChanged("password123")
+
+    viewModel.clearFields()
+
+    val currentState = viewModel.uiState.first()
+    assertEquals("", currentState.email)
+    assertEquals("", currentState.password)
+  }
+
+  @Test
+  fun `loginUser triggers onError when email is blank`() = runTest {
+    viewModel.onEmailChanged("")
+    viewModel.onPasswordChanged("password123")
+
+    var successCalled = false
+    var errorCalled = false
+
+    viewModel.loginUser(onSuccess = { successCalled = true }, onError = { errorCalled = true })
+
+    assertFalse(successCalled)
+    assertTrue(errorCalled)
+  }
+
+  @Test
+  fun `loginUser triggers onError when password is blank`() = runTest {
+    viewModel.onEmailChanged("test@example.com")
+    viewModel.onPasswordChanged("")
+
+    var successCalled = false
+    var errorCalled = false
+
+    viewModel.loginUser(onSuccess = { successCalled = true }, onError = { errorCalled = true })
+
+    assertFalse(successCalled)
+    assertTrue(errorCalled)
+  }
 }

--- a/app/src/test/java/com/github/lookupgroup27/lookup/ui/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/ui/login/LoginViewModelTest.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.ui.login
+
+class LoginViewModelTest {
+}

--- a/app/src/test/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordResetViewModelTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordResetViewModelTest.kt
@@ -1,4 +1,80 @@
 package com.github.lookupgroup27.lookup.ui.passwordreset
 
+import com.github.lookupgroup27.lookup.model.passwordreset.PasswordResetRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
 class PasswordResetViewModelTest {
+
+  private lateinit var viewModel: PasswordResetViewModel
+  private lateinit var mockRepository: PasswordResetRepository
+
+  @Before
+  fun setUp() {
+    mockRepository = mock()
+    viewModel = PasswordResetViewModel(mockRepository)
+
+    Dispatchers.setMain(StandardTestDispatcher())
+  }
+
+  @After
+  fun tearDown() {
+
+    Dispatchers.resetMain()
+  }
+
+  @Test
+  fun `onEmailChanged updates email in uiState`() = runTest {
+    viewModel.onEmailChanged("test@example.com")
+    val currentState = viewModel.uiState.first()
+    assertEquals("test@example.com", currentState.email)
+  }
+
+  @Test
+  fun `clearFields resets email in uiState`() = runTest {
+    viewModel.onEmailChanged("test@example.com")
+    viewModel.clearFields()
+    val currentState = viewModel.uiState.first()
+    assertEquals("", currentState.email)
+  }
+
+  @Test
+  fun `resetPassword triggers success when repository call succeeds`() = runTest {
+    whenever(mockRepository.sendPasswordResetEmail("test@example.com"))
+        .thenReturn(Result.success(Unit))
+
+    viewModel.onEmailChanged("test@example.com")
+
+    viewModel.resetPassword()
+    advanceUntilIdle()
+
+    val currentState = viewModel.uiState.first()
+    assertTrue(currentState.isSuccess)
+    assertFalse(currentState.isLoading)
+    assertNull(currentState.errorMessage)
+  }
+
+  @Test
+  fun `resetPassword sets errorMessage when repository call fails`() = runTest {
+    whenever(mockRepository.sendPasswordResetEmail("test@example.com"))
+        .thenReturn(Result.failure(Exception("Test Error")))
+
+    viewModel.onEmailChanged("test@example.com")
+
+    viewModel.resetPassword()
+    advanceUntilIdle()
+
+    val currentState = viewModel.uiState.first()
+    assertEquals("Test Error", currentState.errorMessage)
+    assertFalse(currentState.isSuccess)
+    assertFalse(currentState.isLoading)
+  }
 }

--- a/app/src/test/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordResetViewModelTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordResetViewModelTest.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.ui.passwordreset
+
+class PasswordResetViewModelTest {
+}

--- a/app/src/test/java/com/github/lookupgroup27/lookup/ui/register/RegisterViewModelTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/ui/register/RegisterViewModelTest.kt
@@ -1,4 +1,84 @@
 package com.github.lookupgroup27.lookup.ui.register
 
+import com.github.lookupgroup27.lookup.model.register.RegisterRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
 class RegisterViewModelTest {
+
+  private lateinit var viewModel: RegisterViewModel
+  private lateinit var mockRepository: MockRegisterRepository
+
+  private val testDispatcher = StandardTestDispatcher()
+
+  @Before
+  fun setUp() {
+    Dispatchers.setMain(testDispatcher)
+    mockRepository = MockRegisterRepository()
+    viewModel = RegisterViewModel(mockRepository)
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
+  }
+
+  @Test
+  fun `onEmailChanged updates email state`() {
+    viewModel.onEmailChanged("test@example.com")
+    assertEquals("test@example.com", viewModel.uiState.value.email)
+  }
+
+  @Test
+  fun `onPasswordChanged updates password state`() {
+    viewModel.onPasswordChanged("password123")
+    assertEquals("password123", viewModel.uiState.value.password)
+  }
+
+  @Test
+  fun `clearFields resets state`() {
+    viewModel.onEmailChanged("test@example.com")
+    viewModel.onPasswordChanged("password123")
+    viewModel.clearFields()
+    assertEquals("", viewModel.uiState.value.email)
+    assertEquals("", viewModel.uiState.value.password)
+  }
+
+  @Test
+  fun `registerUser calls repository and triggers onSuccess`() = runTest {
+    var successCalled = false
+    var errorCalled = false
+
+    viewModel.onEmailChanged("test@example.com")
+    viewModel.onPasswordChanged("password123")
+
+    viewModel.registerUser(onSuccess = { successCalled = true }, onError = { errorCalled = true })
+
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    assertTrue(successCalled)
+    assertFalse(errorCalled)
+  }
+
+  @Test
+  fun `registerUser with blank email triggers onError`() = runTest {
+    var successCalled = false
+    var errorCalled = false
+
+    viewModel.onPasswordChanged("password123")
+    viewModel.registerUser(onSuccess = { successCalled = true }, onError = { errorCalled = true })
+
+    assertFalse(successCalled)
+    assertTrue(errorCalled)
+  }
+}
+
+class MockRegisterRepository : RegisterRepository {
+  override suspend fun registerUser(email: String, password: String) {}
 }

--- a/app/src/test/java/com/github/lookupgroup27/lookup/ui/register/RegisterViewModelTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/ui/register/RegisterViewModelTest.kt
@@ -1,0 +1,4 @@
+package com.github.lookupgroup27.lookup.ui.register
+
+class RegisterViewModelTest {
+}


### PR DESCRIPTION

This PR adds the complete implementation of login, registration, and password reset functionalities, including UI, ViewModels, repositories, and tests. The navigation flow has also been updated to integrate these features. Below is a summary:

## Changes:
1. **Login Feature**:
   - `LoginScreen`: Email/password input fields with navigation to password reset.
   - `LoginViewModel`: Handles state and Firebase interactions.
   - `LoginRepositoryFirestore`: Implements Firebase-based authentication.
   - **Tests**: Added unit/UI tests for repository, ViewModel, and UI.

2. **Register Feature**:
   - `RegisterScreen`: Email/password fields for new user registration.
   - `RegisterViewModel`: Manages registration logic and state.
   - `RegisterRepositoryFirestore`: Handles Firebase-based user creation.
   - **Tests**: Added unit/UI tests for repository, ViewModel, and UI.

3. **Password Reset Feature**:
   - `PasswordResetScreen`: Allows users to send reset emails.
   - `PasswordResetViewModel`: Handles state and repository calls.
   - `PasswordResetRepositoryFirestore`: Integrates with Firebase for reset emails.
   - **Tests**: Added unit/UI tests for repository, ViewModel, and UI.

4. **Navigation Updates**:
   - Integrated new screens into `NavigationActions` and `MainActivity`.

5. **Sign-In Refactor**:
   - Enhanced `SignIn` composable with login, register, and password reset navigation buttons.

