### PR TITLE
fix: correctly highlight buttons in Google Map screen

### DIFF
--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/components/MapControls.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/components/MapControls.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -23,8 +24,20 @@ import com.github.lookupgroup27.lookup.ui.theme.*
 fun MapControls(autoCenteringEnabled: Boolean, onCenteringToggle: (Boolean) -> Unit) {
   Box(modifier = Modifier.fillMaxWidth().background(DarkBlue).padding(16.dp)) {
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-      Button(onClick = { onCenteringToggle(true) }) { Text(text = "Auto Center On") }
-      Button(onClick = { onCenteringToggle(false) }) { Text(text = "Auto Center Off") }
+      Button(
+          onClick = { onCenteringToggle(true) },
+          colors =
+              ButtonDefaults.buttonColors(
+                  containerColor = if (autoCenteringEnabled) DarkPurple else DarkBlue)) {
+            Text(text = "Auto Center On")
+          }
+      Button(
+          onClick = { onCenteringToggle(false) },
+          colors =
+              ButtonDefaults.buttonColors(
+                  containerColor = if (!autoCenteringEnabled) DarkPurple else DarkBlue)) {
+            Text(text = "Auto Center Off")
+          }
     }
   }
 }


### PR DESCRIPTION
Modified the MapControls Composable to correctly indicate if the Auto Centering buttons have been clicked on in the Google Map screen.