### PR TITLE
Fix ImageViewModel package

### DIFF
--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImageReview.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImageReview.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.rememberAsyncImagePainter
 import com.github.lookupgroup27.lookup.model.image.FirebaseImageRepository
-import com.github.lookupgroup27.lookup.model.image.ImageViewModel
 import com.github.lookupgroup27.lookup.model.location.LocationProviderSingleton
 import com.github.lookupgroup27.lookup.model.post.Post
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImageViewModel.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImageViewModel.kt
@@ -1,8 +1,9 @@
-package com.github.lookupgroup27.lookup.model.image
+package com.github.lookupgroup27.lookup.ui.image
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.github.lookupgroup27.lookup.model.image.ImageRepository
 import java.io.File
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/test/java/com/github/lookupgroup27/lookup/ui/image/ImageViewModelTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/ui/image/ImageViewModelTest.kt
@@ -1,6 +1,7 @@
-package com.github.lookupgroup27.lookup.model.image
+package com.github.lookupgroup27.lookup.ui.image
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.github.lookupgroup27.lookup.model.image.FirebaseImageRepository
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Oct 06 19:46:00 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Description

This pull request refactors the codebase by reorganizing files related to the `ImageViewModel` and its associated tests. Specifically:

- **Renamed and moved**:
  - `ImageViewModel.kt` from the `model/image` package to the `ui/image` package.
  - `ImageViewModelTest.kt` from the `model/image` package to the `ui/image` package.
- Updated package declarations to reflect the new location of the files.

> [!IMPORTANT]
This pull request also address an update to the gradle wrapper version. This will make sure the project is up to date with the latest version of gradle.