### PR TITLE
feat: make feed time sensitive

### DIFF
--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/image/ImageReviewKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/image/ImageReviewKtTest.kt
@@ -62,7 +62,12 @@ class ImageReviewTest {
   fun testImageReviewIsDisplayed() {
     composeTestRule.setContent {
       ImageReviewScreen(
-          mockNavigationActions, fakeFile, imageViewModel, postsViewModel, collectionViewModel)
+          mockNavigationActions,
+          fakeFile,
+          imageViewModel,
+          postsViewModel,
+          collectionViewModel,
+          timestamp = 123456789L)
     }
 
     composeTestRule.onNodeWithTag("image_review").assertIsDisplayed()
@@ -72,7 +77,12 @@ class ImageReviewTest {
   fun testConfirmButtonIsDisplayedAndClickable() {
     composeTestRule.setContent {
       ImageReviewScreen(
-          mockNavigationActions, fakeFile, imageViewModel, postsViewModel, collectionViewModel)
+          mockNavigationActions,
+          fakeFile,
+          imageViewModel,
+          postsViewModel,
+          collectionViewModel,
+          timestamp = 123456789L)
     }
 
     composeTestRule.onNodeWithTag("confirm_button").performScrollTo().assertIsDisplayed()
@@ -83,7 +93,12 @@ class ImageReviewTest {
   fun testCancelButtonIsDisplayedAndClickable() {
     composeTestRule.setContent {
       ImageReviewScreen(
-          mockNavigationActions, fakeFile, imageViewModel, postsViewModel, collectionViewModel)
+          mockNavigationActions,
+          fakeFile,
+          imageViewModel,
+          postsViewModel,
+          collectionViewModel,
+          timestamp = 123456789L)
     }
 
     composeTestRule.onNodeWithTag("cancel_button").performScrollTo().assertIsDisplayed()
@@ -101,7 +116,8 @@ class ImageReviewTest {
           imageFile = imageFile,
           imageViewModel,
           postsViewModel,
-          collectionViewModel)
+          collectionViewModel,
+          timestamp = 123456789L)
     }
     composeTestRule.onNodeWithContentDescription("Captured Image").assertIsDisplayed()
   }
@@ -114,7 +130,8 @@ class ImageReviewTest {
           imageFile = null,
           imageViewModel,
           postsViewModel,
-          collectionViewModel)
+          collectionViewModel,
+          timestamp = 123456789L)
     }
     composeTestRule.onNodeWithText("No image available").assertIsDisplayed()
   }
@@ -123,7 +140,12 @@ class ImageReviewTest {
   fun testImageReviewScreenIsScrollable() {
     composeTestRule.setContent {
       ImageReviewScreen(
-          mockNavigationActions, fakeFile, imageViewModel, postsViewModel, collectionViewModel)
+          mockNavigationActions,
+          fakeFile,
+          imageViewModel,
+          postsViewModel,
+          collectionViewModel,
+          timestamp = 123456789L)
     }
 
     // Check that the top element is displayed (e.g., image or text)
@@ -139,7 +161,12 @@ class ImageReviewTest {
   fun testBackgroundImageIsDisplayed() {
     composeTestRule.setContent {
       ImageReviewScreen(
-          mockNavigationActions, fakeFile, imageViewModel, postsViewModel, collectionViewModel)
+          mockNavigationActions,
+          fakeFile,
+          imageViewModel,
+          postsViewModel,
+          collectionViewModel,
+          timestamp = 123456789L)
     }
     composeTestRule.onNodeWithTag("background_image").assertIsDisplayed()
   }
@@ -150,7 +177,12 @@ class ImageReviewTest {
     imageViewModel.setEditImageState(ImageViewModel.UploadStatus(isLoading = true))
     composeTestRule.setContent {
       ImageReviewScreen(
-          mockNavigationActions, fakeFile, imageViewModel, postsViewModel, collectionViewModel)
+          mockNavigationActions,
+          fakeFile,
+          imageViewModel,
+          postsViewModel,
+          collectionViewModel,
+          timestamp = 123456789L)
     }
     composeTestRule.onNodeWithTag("loading_indicator").assertIsDisplayed()
   }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/MainActivity.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/MainActivity.kt
@@ -142,7 +142,7 @@ fun LookUpApp() {
       }
 
       composable(
-          route = "${Route.EDIT_IMAGE}/{imageUrl}",
+          route = "${Route.EDIT_IMAGE}/{imageUrl}/{timestamp}",
           arguments = listOf(navArgument("imageUrl") { type = NavType.StringType })) {
               backStackEntry ->
             val imageUrl = backStackEntry.arguments?.getString("imageUrl")
@@ -160,16 +160,20 @@ fun LookUpApp() {
     navigation(startDestination = Screen.TAKE_IMAGE, route = Route.TAKE_IMAGE) {
       composable(Screen.TAKE_IMAGE) { CameraCapture(navigationActions) }
       composable(
-          route = "${Route.IMAGE_REVIEW}/{imageFile}",
-          arguments = listOf(navArgument("imageFile") { type = NavType.StringType })) {
-              backStackEntry ->
+          route = "${Route.IMAGE_REVIEW}/{imageFile}/{timestamp}",
+          arguments =
+              listOf(
+                  navArgument("imageFile") { type = NavType.StringType },
+                  navArgument("timestamp") { type = NavType.LongType })) { backStackEntry ->
             val imageFile = backStackEntry.arguments?.getString("imageFile")?.let { File(it) }
+            val timestamp = backStackEntry.arguments?.getLong("timestamp") // Extract the timestamp
             ImageReviewScreen(
                 navigationActions = navigationActions,
                 imageFile = imageFile,
                 imageViewModel = imageViewModel,
                 postsViewModel = postsViewModel,
-                collectionViewModel = collectionViewModel)
+                collectionViewModel = collectionViewModel,
+                timestamp = timestamp)
           }
     }
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/feed/ProximityFetcher.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/feed/ProximityFetcher.kt
@@ -59,8 +59,11 @@ class ProximityPostFetcher(private val postsViewModel: PostsViewModel, context: 
                     // Pair each post with its distance from the user
                     post to distance
                   }
-                  // Sort posts by distance in ascending order
-                  .sortedBy { (_, distance) -> distance }
+                  // Sort first by distance (ascending), then by timestamp (descending)
+                  .sortedWith(
+                      compareBy<Pair<Post, Double>> { it.second } // Sort by distance
+                          .thenByDescending { it.first.timestamp } // Sort by timestamp
+                      )
                   // Take the 3 closest posts for now
                   .take(3)
                   // Extract only the post objects from the pairs

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/feed/ProximityFetcher.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/feed/ProximityFetcher.kt
@@ -15,13 +15,13 @@ import kotlinx.coroutines.launch
 
 /**
  * ProximityPostFetcher is responsible for fetching posts and filtering them based on their
- * proximity to the user's current location. It updates a list of nearby posts based on distance
- * from the user.
+ * proximity to the user's current location and also on the time the posts were taken. It updates a
+ * list of the most recent and nearby posts based on distance from the user.
  *
  * @param postsViewModel ViewModel to access the list of all posts
  * @param context Application context to access the singleton LocationProvider
  */
-class ProximityPostFetcher(private val postsViewModel: PostsViewModel, context: Context) {
+class ProximityAndTimePostFetcher(private val postsViewModel: PostsViewModel, context: Context) {
   // LocationProvider instance to get user's current location
   private val locationProvider = LocationProviderSingleton.getInstance(context)
 
@@ -30,10 +30,10 @@ class ProximityPostFetcher(private val postsViewModel: PostsViewModel, context: 
   val nearbyPosts: StateFlow<List<Post>> = _nearbyPosts
 
   /**
-   * Fetches nearby posts with images based on the user's current location. Filters and sorts posts
-   * by distance, limiting results to the 3 closest posts.
+   * Fetches nearby posts with images based on the user's current location and the time they were
+   * posted. Filters and sorts posts by distance and time, limiting results to the 3 closest posts.
    */
-  fun fetchNearbyPostsWithImages() {
+  fun fetchSortedPosts() {
     val userLocation = locationProvider.currentLocation.value
     if (userLocation == null) {
       Log.e("ProximityPostFetcher", "User location is null; cannot fetch nearby posts.")

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/post/Post.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/post/Post.kt
@@ -9,5 +9,6 @@ data class Post(
     val latitude: Double = 0.0,
     val longitude: Double = 0.0,
     val usersNumber: Int = 0,
-    val ratedBy: List<String> = emptyList()
+    val ratedBy: List<String> = emptyList(),
+    val timestamp: Long = 0L
 )

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/post/PostsRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/post/PostsRepositoryFirestore.kt
@@ -69,7 +69,8 @@ class PostsRepositoryFirestore(private val db: FirebaseFirestore) : PostsReposit
                       data["latitude"] as Double,
                       data["longitude"] as Double,
                       (data["usersNumber"] as? Long)?.toInt() ?: 0,
-                      data["ratedBy"] as? List<String> ?: emptyList())
+                      data["ratedBy"] as? List<String> ?: emptyList(),
+                      (data["timestamp"] as? Long) ?: 0L)
                 }
                 .filterNotNull()
         onSuccess(posts)

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/feed/Feed.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/feed/Feed.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import com.github.lookupgroup27.lookup.R
-import com.github.lookupgroup27.lookup.model.feed.ProximityPostFetcher
+import com.github.lookupgroup27.lookup.model.feed.ProximityAndTimePostFetcher
 import com.github.lookupgroup27.lookup.model.location.LocationProviderSingleton
 import com.github.lookupgroup27.lookup.model.post.Post
 import com.github.lookupgroup27.lookup.model.profile.UserProfile
@@ -65,12 +65,14 @@ fun FeedScreen(
 
   val context = LocalContext.current
   val locationProvider = LocationProviderSingleton.getInstance(context)
-  val proximityPostFetcher = remember { ProximityPostFetcher(postsViewModel, context) }
+  val proximityAndTimePostFetcher = remember {
+    ProximityAndTimePostFetcher(postsViewModel, context)
+  }
 
   var locationPermissionGranted by remember { mutableStateOf(false) }
   val unfilteredPosts by
       (initialNearbyPosts?.let { mutableStateOf(it) }
-          ?: proximityPostFetcher.nearbyPosts.collectAsState())
+          ?: proximityAndTimePostFetcher.nearbyPosts.collectAsState())
   val nearbyPosts = unfilteredPosts.filter { it.username != userEmail }
 
   val postRatings = remember { mutableStateMapOf<String, List<Boolean>>() }
@@ -89,7 +91,7 @@ fun FeedScreen(
       while (locationProvider.currentLocation.value == null) {
         kotlinx.coroutines.delay(500)
       }
-      proximityPostFetcher.fetchNearbyPostsWithImages()
+      proximityAndTimePostFetcher.fetchSortedPosts()
     }
   }
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImageReview.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImageReview.kt
@@ -40,10 +40,12 @@ fun ImageReviewScreen(
     imageFile: File?,
     imageViewModel: ImageViewModel = viewModel(),
     postsViewModel: PostsViewModel = viewModel(),
-    collectionViewModel: CollectionViewModel = viewModel()
+    collectionViewModel: CollectionViewModel = viewModel(),
+    timestamp: Long?
 ) {
   val context = LocalContext.current
   val locationProvider = LocationProviderSingleton.getInstance(context)
+  val currentTimestamp = timestamp ?: System.currentTimeMillis() // Fallback to current time
 
   val uploadStatus by imageViewModel.uploadStatus.collectAsState()
 
@@ -128,7 +130,8 @@ fun ImageReviewScreen(
                       uri = downloadUrl,
                       username = FirebaseAuth.getInstance().currentUser?.displayName ?: "Anonymous",
                       latitude = currentLocation.latitude,
-                      longitude = currentLocation.longitude)
+                      longitude = currentLocation.longitude,
+                      timestamp = currentTimestamp)
               // Add the post to PostsViewModel
               postsViewModel.addPost(newPost)
               collectionViewModel.updateImages()

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/TakeImage.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/TakeImage.kt
@@ -135,7 +135,8 @@ fun CameraCapture(
                   override fun onImageSaved(output: ImageCapture.OutputFileResults) {
                     val savedUri =
                         Uri.encode(photoFile.absolutePath) // Encoded URI of the saved image
-                    navigationActions.navigateToWithImage(savedUri, Route.IMAGE_REVIEW)
+                    val timestamp = System.currentTimeMillis()
+                    navigationActions.navigateToWithImage(savedUri, Route.IMAGE_REVIEW, timestamp)
                   }
 
                   override fun onError(exc: ImageCaptureException) {

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/NavigationActions.kt
@@ -112,11 +112,13 @@ open class NavigationActions(
   }
 
   /**
-   * Navigate to the a screen with a specific imageUri.
+   * Navigate to a screen with a specific imageUri and timestamp.
    *
    * @param image The URI of the captured image to review.
+   * @param route The route to navigate to.
+   * @param timestamp The timestamp of when the image was captured.
    */
-  open fun navigateToWithImage(image: String, route: String) {
-    navController.navigate("${route}/$image")
+  open fun navigateToWithImage(image: String, route: String, timestamp: Long) {
+    navController.navigate("${route}/$image/$timestamp")
   }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/Collection.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/Collection.kt
@@ -118,8 +118,9 @@ fun CollectionScreen(
                                                       URLEncoder.encode(
                                                           imageUrl,
                                                           StandardCharsets.UTF_8.toString())
+                                                  val timestamp = System.currentTimeMillis()
                                                   navigationActions.navigateToWithImage(
-                                                      encodedImageUrl, Route.EDIT_IMAGE)
+                                                      encodedImageUrl, Route.EDIT_IMAGE, timestamp)
                                                 }
                                                 .background(
                                                     MaterialTheme.colorScheme.surface.copy(

--- a/app/src/test/java/com/github/lookupgroup27/lookup/model/feed/ProximityAndTimePostFetcherTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/model/feed/ProximityAndTimePostFetcherTest.kt
@@ -28,14 +28,14 @@ import org.robolectric.RobolectricTestRunner
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
-class ProximityPostFetcherTest {
+class ProximityAndTimePostFetcherTest {
 
   @Mock private lateinit var mockFirestore: FirebaseFirestore
   @Mock private lateinit var mockCollectionReference: CollectionReference
 
   private lateinit var postsRepositoryFirestore: PostsRepositoryFirestore
   private lateinit var postsViewModel: PostsViewModel
-  private lateinit var proximityPostFetcher: ProximityPostFetcher
+  private lateinit var proximityAndTimePostFetcher: ProximityAndTimePostFetcher
   private lateinit var context: Context
   private lateinit var locationProvider: TestLocationProvider
   private lateinit var postsRepository: PostsRepository
@@ -55,7 +55,7 @@ class ProximityPostFetcherTest {
     postsRepositoryFirestore = PostsRepositoryFirestore(mockFirestore)
     postsViewModel = PostsViewModel(postsRepositoryFirestore)
 
-    proximityPostFetcher = ProximityPostFetcher(postsViewModel, context)
+    proximityAndTimePostFetcher = ProximityAndTimePostFetcher(postsViewModel, context)
     locationProvider = TestLocationProvider()
   }
 
@@ -70,13 +70,13 @@ class ProximityPostFetcherTest {
     locationProvider.setLocation(null, null)
 
     // Call the function
-    proximityPostFetcher.fetchNearbyPostsWithImages()
+    proximityAndTimePostFetcher.fetchSortedPosts()
 
     // Wait for any asynchronous updates
     testScheduler.advanceUntilIdle()
 
     // Assert that no nearby posts are returned when location is null
-    assertTrue(proximityPostFetcher.nearbyPosts.value.isEmpty())
+    assertTrue(proximityAndTimePostFetcher.nearbyPosts.value.isEmpty())
   }
 
   @Test
@@ -90,13 +90,13 @@ class ProximityPostFetcherTest {
     }
 
     // Fetch posts
-    proximityPostFetcher.fetchNearbyPostsWithImages()
+    proximityAndTimePostFetcher.fetchSortedPosts()
 
     // Wait for asynchronous updates
     testScheduler.advanceUntilIdle()
 
     // Assert that no nearby posts are returned when there are no posts in the repository
-    assertTrue(proximityPostFetcher.nearbyPosts.value.isEmpty())
+    assertTrue(proximityAndTimePostFetcher.nearbyPosts.value.isEmpty())
   }
 
   /** TestLocationProvider allows for manual setting of location values. */

--- a/app/src/test/java/com/github/lookupgroup27/lookup/model/post/PostsRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/model/post/PostsRepositoryFirestoreTest.kt
@@ -58,7 +58,8 @@ class PostsRepositoryFirestoreTest {
           0.0,
           0.0,
           2,
-          listOf("test@gmail.com", "joedoe@gmail.com"))
+          listOf("test@gmail.com", "joedoe@gmail.com"),
+          0L)
 
   /**
    * Sets up the test environment before each test.

--- a/app/src/test/java/com/github/lookupgroup27/lookup/ui/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/ui/navigation/NavigationActionsTest.kt
@@ -85,4 +85,17 @@ class NavigationActionsTest {
     assertThat(navOptionsBuilder.launchSingleTop, `is`(true))
     assertThat(navOptionsBuilder.restoreState, `is`(true))
   }
+
+  @Test
+  fun navigateToWithImageAndTimestampCallsControllerWithCorrectRoute() {
+    // Arrange
+    val imageUri = "sample_image_uri"
+    val timestamp = 1620000000000L
+
+    // Act
+    navigationActions.navigateToWithImage(imageUri, Route.IMAGE_REVIEW, timestamp)
+
+    // Assert
+    verify(navHostController).navigate("${Route.IMAGE_REVIEW}/$imageUri/$timestamp")
+  }
 }


### PR DESCRIPTION
This pull request updates the feed to make it time-sensitive, ensuring that more recent posts appear higher in the feed while maintaining proximity-based sorting.

- Added a timestamp field to the `Post` class, with a default value of 0L to ensure backward compatibility.
- Updated the `ProximityPostFetcher` to sort posts not only by proximity but also by recency, with more recent posts appearing higher in the feed.
- Modified the getPosts method in `PostsRepositoryFirestore` to handle the timestamp field when retrieving posts from Firestore.

Note: The code coverage for this PR is lower than expected because some lines of pre-existing code are not covered. These lines were not introduced or modified as part of this PR and include areas like the collection screen, parts of the ProximityPostFetcher, and TakeImage. Adding tests for these areas falls outside the scope of this PR.