### PR TITLE
Display location and add description attribute to posts

### DIFF
--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/feed/FeedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/feed/FeedScreenTest.kt
@@ -69,31 +69,36 @@ class FeedScreenTest {
               uri = "http://example.com/1.jpg",
               username = testUserProfile.email, // Post created by the logged-in user
               latitude = 37.7749, // San Francisco
-              longitude = -122.4194),
+              longitude = -122.4194,
+              description = "This is a test description"),
           Post(
               uid = "2",
               uri = "http://example.com/2.jpg",
               username = "User2", // Post created by another user
               latitude = 34.0522, // Los Angeles
-              longitude = -118.2437),
+              longitude = -118.2437,
+              description = "This is another test description"),
           Post(
               uid = "3",
               uri = "http://example.com/3.jpg",
               username = "User3", // Another user's post
               latitude = 36.7783, // Fresno (closer to SF)
-              longitude = -119.4179),
+              longitude = -119.4179,
+              description = "This is yet another test description"),
           Post(
               uid = "4",
               uri = "User4",
               username = "user4@example.com", // Another user's post
               latitude = 40.7128, // New York City (farther from SF than LA or Fresno)
-              longitude = -74.0060),
+              longitude = -74.0060,
+              description = "This is a test description"),
           Post(
               uid = "5",
               uri = "User5",
               username = "user5@example.com", // Another user's post
               latitude = -33.8688, // Sydney, Australia (farthest from SF)
-              longitude = 151.2093))
+              longitude = 151.2093,
+              description = "This is a test description"))
 
   private val testPost =
       Post(
@@ -190,9 +195,7 @@ class FeedScreenTest {
     postsViewModel.updatePost(testPost)
 
     // Verify that updatePost was called in the postsViewModel
-    verify(postsRepository)
-        .updatePost(
-            org.mockito.kotlin.eq(testPost), org.mockito.kotlin.any(), org.mockito.kotlin.any())
+    verify(postsRepository).updatePost(eq(testPost), any(), any())
   }
 
   /*@Test
@@ -216,5 +219,21 @@ class FeedScreenTest {
 
     // Verify that the navigation action to the Feed was not triggered
     verify(navigationActions, never()).navigateTo(eq(TopLevelDestinations.FEED))
+  }
+
+  @Test
+  fun testAddressIsDisplayed() {
+    // Verify that the address is displayed for each post
+    composeTestRule.onNodeWithTag("AddressTag_2").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("AddressTag_3").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("AddressTag_5").assertDoesNotExist()
+  }
+
+  @Test
+  fun testDescriptionIsDisplayed() {
+    // Verify that the description is displayed for each post
+    composeTestRule.onNodeWithTag("DescriptionTag_2").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DescriptionTag_3").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DescriptionTag_5").assertDoesNotExist()
   }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/post/Post.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/post/Post.kt
@@ -9,5 +9,6 @@ data class Post(
     val latitude: Double = 0.0,
     val longitude: Double = 0.0,
     val usersNumber: Int = 0,
-    val ratedBy: List<String> = emptyList()
+    val ratedBy: List<String> = emptyList(),
+    val description: String = "",
 )

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/post/PostsRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/post/PostsRepositoryFirestore.kt
@@ -69,7 +69,8 @@ class PostsRepositoryFirestore(private val db: FirebaseFirestore) : PostsReposit
                       data["latitude"] as Double,
                       data["longitude"] as Double,
                       (data["usersNumber"] as? Long)?.toInt() ?: 0,
-                      data["ratedBy"] as? List<String> ?: emptyList())
+                      data["ratedBy"] as? List<String> ?: emptyList(),
+                      data["description"] as? String ?: "")
                 }
                 .filterNotNull()
         onSuccess(posts)


### PR DESCRIPTION
This PR introduces two major enhancements:
**1. Display Location as Street Name:**
        - Fetches the street name from latitude and longitude using the Nominatim API.
        - Updates the PostItem composable to display the fetched street name below the username.
**2. Add Description Attribute:**
          - Introduces a description field for posts to provide more context or details.
         
**Changes Made:**
- Updated PostItem composable to include the address and description.
- Address fetching is now fully asynchronous to prevent blocking the UI thread.

**Tests Checklist:**
The following tests need to be implemented for the getAddressFromLatLngUsingNominatim function:

- [ ] Test valid address fetching:
        Mock a successful API response from Nominatim with a valid display_name.
        Verify that the returned address matches the mocked response.

- [ ] Test handling of empty API responses:
       Mock an API response with no display_name or an empty response body.
       Ensure the function returns "Address not found".

- [ ] Test handling of HTTP errors:
      Simulate HTTP errors (e.g., 404, 500) and verify appropriate error messages are returned.

- [ ] Test invalid coordinates:
      Pass out-of-range or invalid latitude and longitude values.
      Ensure the function handles these inputs gracefully and does not crash.

- [ ] Test network-related errors:
      Simulate network issues such as timeouts or unreachable servers.
      Verify that the function returns a proper error message.
