### PR TITLE
Ensure Stars Render in White

### DIFF
--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/map/renderables/CircleRenderer.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/map/renderables/CircleRenderer.kt
@@ -13,15 +13,15 @@ import com.github.lookupgroup27.lookup.util.opengl.ShaderProgram
 /**
  * Renderer for creating circular 2D objects in an OpenGL environment.
  *
- * @param segments Number of segments used to approximate the circle (default is 32)
+ * @param segments Number of segments used to approximate the circle (default is DEFAULT_SEGMENTS)
  * @param radius Radius of the circle (default is 1.0f)
- * @param color Color of the circle as an integer (RGBA)
+ * @param color Color of the circle in RGBA format (range 0-255) (default is white)
  */
 open class CircleRenderer(
     private val context: Context,
     private val segments: Int = DEFAULT_SEGMENTS,
     private val radius: Float = 1.0f,
-    private val color: FloatArray = floatArrayOf(1.0f, 1.0f, 1.0f, 1.0f)
+    private val color: IntArray = intArrayOf(255, 255, 255, 255)
 ) {
   /** Buffer for storing vertex positions. */
   private val vertexBuffer = VertexBuffer()
@@ -54,22 +54,12 @@ open class CircleRenderer(
     }
 
     // Add indices to the index buffer
-    for (index in geometryData.indices) {
-      indexBuffer.addIndex(index)
-    }
-
-    // Convert float color to integer color for buffer
-    val colorInt =
-        ((color[3] * 255).toInt() shl
-            24 or
-            (color[0] * 255).toInt() shl
-            16 or
-            (color[1] * 255).toInt() shl
-            8 or
-            (color[2] * 255).toInt())
+    for (index in geometryData.indices) indexBuffer.addIndex(index)
 
     // Apply a single color for all vertices
-    repeat(geometryData.vertices.size / 3) { colorBuffer.addColor(colorInt) }
+    repeat(geometryData.vertices.size / 3) {
+      colorBuffer.addColor(color[3], color[0], color[1], color[2])
+    }
   }
 
   /** Initializes shaders for rendering the circle. */

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/map/renderables/Star.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/map/renderables/Star.kt
@@ -9,14 +9,14 @@ import com.github.lookupgroup27.lookup.model.map.Camera
  *
  * @param context The Android context for resource management
  * @param position The x, y, z coordinates of the star
- * @param color The color of the star, specified as an RGBA float array
+ * @param color The color of the star, specified as an RGBA array (range 0-255) (default is white)
  * @param size The size of the star (scale factor for its radius)
  * @param segments The number of segments used to approximate the circle (default is 32)
  */
 class Star(
     val context: Context,
     val position: FloatArray,
-    val color: FloatArray,
+    val color: IntArray = intArrayOf(255, 255, 255, 255),
     val size: Float = 0.5f,
     val segments: Int = CircleRenderer.DEFAULT_SEGMENTS
 ) : Object() {

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/map/skybox/buffers/ColorBuffer.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/map/skybox/buffers/ColorBuffer.kt
@@ -66,7 +66,7 @@ class ColorBuffer {
         COLORS_PER_VERTEX,
         GLES20.GL_UNSIGNED_BYTE,
         true, // Normalize the values to [0, 1]
-        COLORS_PER_VERTEX * Int.SIZE_BYTES,
+        0,
         colorBuffer)
   }
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/map/skybox/buffers/ColorBuffer.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/map/skybox/buffers/ColorBuffer.kt
@@ -42,7 +42,7 @@ class ColorBuffer {
    */
   fun addColor(a: Int, r: Int, g: Int, b: Int) {
     val color =
-        ((a and 0xFF) shl 24) or ((r and 0xFF) shl 16) or ((g and 0xFF) shl 8) or (b and 0xFF)
+        ((a and 0xFF) shl 24) or ((b and 0xFF) shl 16) or ((g and 0xFF) shl 8) or (r and 0xFF)
     colorBuffer?.put(color)
   }
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/map/stars/StarsLoader.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/map/stars/StarsLoader.kt
@@ -26,7 +26,6 @@ class StarsLoader(private val context: Context, private val repository: StarData
       Star(
           context = context,
           position = floatArrayOf(starData.x.toFloat(), starData.y.toFloat(), starData.z.toFloat()),
-          color = floatArrayOf(1.0f, 1.0f, 1.0f),
           size = 0.2f)
     }
   }


### PR DESCRIPTION
## Summary
This pull request standardizes the color handling for stars in the project, ensuring that they render with a default white color unless explicitly specified.

### Changes
- Updated `Star.kt`:
  - Changed the `color` property to use an `IntArray` representation for RGBA with a default value of `intArrayOf(255, 255, 255, 255)` (white).
- Updated `CircleRenderer.kt`:
  - Refactored color handling logic to align with the new `IntArray` RGBA representation.
  - Simplified vertex color application logic.
- Updated `StarsLoader.kt`:
  - Removed unnecessary color initialization when creating `Star` instances.