### PR TITLE
feat: enforce unique usernames during registration and enhance related UI and tests

### DIFF
--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/register/RegisterKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/register/RegisterKtTest.kt
@@ -11,7 +11,9 @@ import org.junit.Rule
 import org.junit.Test
 
 class MockRegisterRepository : RegisterRepository {
-  override suspend fun registerUser(email: String, password: String) {}
+  override suspend fun registerUser(email: String, password: String, username: String) {
+    // Mock implementation, does nothing.
+  }
 }
 
 class RegisterKtTest {
@@ -41,6 +43,14 @@ class RegisterKtTest {
       RegisterScreen(viewModel = createMockViewModel(), navigationActions = mockNavigationActions())
     }
     composeTestRule.onNodeWithTag("screen_title").assertIsDisplayed()
+  }
+
+  @Test
+  fun usernameField_isDisplayed() {
+    composeTestRule.setContent {
+      RegisterScreen(viewModel = createMockViewModel(), navigationActions = mockNavigationActions())
+    }
+    composeTestRule.onNodeWithTag("username_field").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterRepository.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterRepository.kt
@@ -4,16 +4,24 @@ package com.github.lookupgroup27.lookup.model.register
  * Interface defining the contract for user registration repositories.
  *
  * Implementations of this interface are responsible for handling the registration logic, such as
- * interacting with authentication services like FirebaseAuth.
+ * interacting with authentication services like FirebaseAuth, as well as Firestore for username
+ * uniqueness checks.
  */
 interface RegisterRepository {
 
   /**
-   * Registers a new user with the provided email and password.
+   * Registers a new user with the provided email, password, and username.
+   *
+   * This method also ensures that the chosen username is unique among existing users.
    *
    * @param email The email address of the new user.
    * @param password The password for the new user.
-   * @throws Exception If an error occurs during the registration process.
+   * @param username The desired unique username for the new user.
+   * @throws UsernameAlreadyExistsException If the username is already associated with an existing
+   *   user.
+   * @throws UserAlreadyExistsException If the email is already associated with an existing account.
+   * @throws WeakPasswordException If the password does not meet Firebase's security requirements.
+   * @throws Exception For any other unexpected errors during the registration process.
    */
-  suspend fun registerUser(email: String, password: String)
+  suspend fun registerUser(email: String, password: String, username: String)
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterRepositoryFirestore.kt
@@ -4,44 +4,66 @@ import android.util.Log
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuthUserCollisionException
 import com.google.firebase.auth.FirebaseAuthWeakPasswordException
+import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
 
 /**
- * Implementation of the [RegisterRepository] interface using Firebase Authentication.
+ * Implementation of the [RegisterRepository] interface using Firebase Authentication and Firestore.
  *
- * This class handles the user registration process by interacting with FirebaseAuth to create new
- * users. It captures specific exceptions thrown by FirebaseAuth and translates them into custom
- * exceptions for better error handling in the ViewModel.
+ * This class handles the user registration process by:
+ * 1. Checking username uniqueness against the Firestore 'users' collection.
+ * 2. Creating the user with Firebase Authentication.
+ * 3. Storing the user's email and username in the Firestore 'users' collection.
  *
- * @property auth The FirebaseAuth instance used to perform authentication operations.
+ * By separating these responsibilities into a repository, we maintain a clean MVVM architecture.
+ *
+ * @property auth The [FirebaseAuth] instance used to perform authentication operations.
+ * @property firestore The [FirebaseFirestore] instance used for username checks and data storage.
  */
-class RegisterRepositoryFirestore(private val auth: FirebaseAuth = FirebaseAuth.getInstance()) :
-    RegisterRepository {
+class RegisterRepositoryFirestore(
+    private val auth: FirebaseAuth = FirebaseAuth.getInstance(),
+    private val firestore: FirebaseFirestore = FirebaseFirestore.getInstance()
+) : RegisterRepository {
 
   /**
-   * Registers a new user with the provided email and password.
+   * Registers a new user with the provided email, password, and username.
    *
-   * This function uses FirebaseAuth to create a new user account. It handles specific exceptions
-   * thrown by FirebaseAuth and rethrows them as custom exceptions to be handled by the ViewModel.
+   * This function first checks whether the desired username is already taken. If not, it proceeds
+   * to create the user with [FirebaseAuth]. Once the user is successfully created, it stores their
+   * user data (email and username) in Firestore for future reference.
    *
    * @param email The email address of the new user.
    * @param password The password for the new user.
+   * @param username The desired unique username for the new user.
+   * @throws UsernameAlreadyExistsException If the chosen username is already taken.
    * @throws UserAlreadyExistsException If the email is already associated with an existing account.
-   * @throws WeakPasswordException If the password does not meet Firebase's security requirements.
-   * @throws Exception For any other errors during the registration process.
+   * @throws WeakPasswordException If the password does not meet security requirements.
+   * @throws Exception If any other unexpected errors occur during registration.
    */
-  override suspend fun registerUser(email: String, password: String) {
+  override suspend fun registerUser(email: String, password: String, username: String) {
     try {
-      // Attempt to create a new user with the provided email and password.
-      auth.createUserWithEmailAndPassword(email, password).await()
+      // Check if username already exists in Firestore.
+      val querySnapshot =
+          firestore.collection("users").whereEqualTo("username", username).limit(1).get().await()
+
+      if (!querySnapshot.isEmpty) {
+        throw UsernameAlreadyExistsException("Username '$username' is already in use.")
+      }
+
+      // Attempt to create a new user in FirebaseAuth.
+      val authResult = auth.createUserWithEmailAndPassword(email, password).await()
+      val uid = authResult.user?.uid ?: throw Exception("Failed to retrieve user UID.")
+
+      // Store user details in Firestore.
+      val userData = mapOf("email" to email, "username" to username)
+      firestore.collection("users").document(uid).set(userData).await()
     } catch (e: FirebaseAuthUserCollisionException) {
-      // Thrown if the email is already in use.
       throw UserAlreadyExistsException("An account with this email already exists.")
     } catch (e: FirebaseAuthWeakPasswordException) {
-      // Thrown if the password is not strong enough.
       throw WeakPasswordException("Your password is too weak.")
+    } catch (e: UsernameAlreadyExistsException) {
+      throw e
     } catch (e: Exception) {
-      // Log the error and rethrow a generic exception for any other errors.
       Log.e("RegisterRepository", "Error creating user", e)
       throw Exception("Registration failed due to an unexpected error.")
     }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterState.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/register/RegisterState.kt
@@ -8,10 +8,12 @@ package com.github.lookupgroup27.lookup.model.register
  *
  * @property email The email input by the user.
  * @property password The password input by the user.
- * @property confirmPassword The confirmation password input by the user.
+ * @property confirmPassword The confirm password input by the user.
+ * @property username The username input by the user.
  * @property emailError Error message related to the email input, if any.
  * @property passwordError Error message related to the password input, if any.
  * @property confirmPasswordError Error message related to the confirm password input, if any.
+ * @property usernameError Error message related to the username input, if any.
  * @property generalError General error message not specific to any field.
  * @property isLoading Indicates whether a registration operation is in progress.
  */
@@ -19,9 +21,11 @@ data class RegisterState(
     val email: String = "",
     val password: String = "",
     val confirmPassword: String = "",
+    val username: String = "",
     val emailError: String? = null,
     val passwordError: String? = null,
     val confirmPasswordError: String? = null,
+    val usernameError: String? = null,
     val generalError: String? = null,
     val isLoading: Boolean = false
 )

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/register/UsernameAlreadyExistsException.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/register/UsernameAlreadyExistsException.kt
@@ -1,10 +1,10 @@
 package com.github.lookupgroup27.lookup.model.register
 
 /**
- * Exception thrown when the provided username is already taken by another user.
+ * Exception thrown when attempting to register with a username that already exists in Firestore.
  *
- * This custom exception allows the application to inform the user that their desired username is
- * already in use, prompting them to choose a different one.
+ * This custom exception allows the application to inform the user that their chosen username is
+ * unavailable, prompting them to choose a different username.
  *
  * @param message The detail message for this exception.
  */

--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/register/UsernameAlreadyExistsException.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/register/UsernameAlreadyExistsException.kt
@@ -1,0 +1,11 @@
+package com.github.lookupgroup27.lookup.model.register
+
+/**
+ * Exception thrown when the provided username is already taken by another user.
+ *
+ * This custom exception allows the application to inform the user that their desired username is
+ * already in use, prompting them to choose a different one.
+ *
+ * @param message The detail message for this exception.
+ */
+class UsernameAlreadyExistsException(message: String) : Exception(message)

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/register/Register.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/register/Register.kt
@@ -20,9 +20,9 @@ import com.github.lookupgroup27.lookup.ui.register.components.CustomOutlinedText
 /**
  * Composable function representing the registration screen.
  *
- * This screen allows users to create a new account by providing their email, password, and
- * confirming their password. It provides real-time validation feedback and handles the registration
- * process asynchronously.
+ * This screen allows users to create a new account by providing their username, email, password,
+ * and confirming their password. It provides real-time validation feedback and handles the
+ * registration process asynchronously.
  *
  * @param navigationActions The navigation actions used to navigate between screens.
  * @param viewModel The [RegisterViewModel] managing the registration logic.
@@ -36,15 +36,24 @@ fun RegisterScreen(
   val context = LocalContext.current
   val uiState by viewModel.uiState.collectAsState()
 
-  // Main container for the screen content.
   Box(modifier = Modifier.fillMaxSize()) {
-    // Base authentication screen layout.
     AuthScreen(
         title = "Create Your Account",
         onBackClicked = {
           viewModel.clearFields()
           navigationActions.navigateTo(Screen.AUTH)
         }) {
+
+          // Username Input Field
+          CustomOutlinedTextField(
+              value = uiState.username,
+              onValueChange = viewModel::onUsernameChanged,
+              label = "Username",
+              errorMessage = uiState.usernameError,
+              testTag = "username_field")
+
+          Spacer(modifier = Modifier.height(16.dp))
+
           // Email Input Field
           CustomOutlinedTextField(
               value = uiState.email,

--- a/app/src/test/java/com/github/lookupgroup27/lookup/model/register/RegisterRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/lookupgroup27/lookup/model/register/RegisterRepositoryFirestoreTest.kt
@@ -1,13 +1,16 @@
 package com.github.lookupgroup27.lookup.model.register
 
+import androidx.test.core.app.ApplicationProvider
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.*
-import kotlinx.coroutines.runBlocking
+import com.google.firebase.firestore.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.*
+import org.junit.*
 import org.junit.Assert.*
-import org.junit.Before
-import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.*
 import org.mockito.Mockito.*
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
@@ -17,64 +20,100 @@ class RegisterRepositoryFirestoreTest {
 
   private lateinit var repository: RegisterRepositoryFirestore
   private lateinit var mockAuth: FirebaseAuth
+  private lateinit var mockFirestore: FirebaseFirestore
+  private lateinit var mockCollectionRef: CollectionReference
+  private lateinit var mockQuery: Query
+
+  private val testDispatcher = StandardTestDispatcher()
 
   @Before
   fun setUp() {
+    Dispatchers.setMain(testDispatcher)
     MockitoAnnotations.openMocks(this)
 
-    if (FirebaseApp.getApps(androidx.test.core.app.ApplicationProvider.getApplicationContext())
-        .isEmpty()) {
-      FirebaseApp.initializeApp(androidx.test.core.app.ApplicationProvider.getApplicationContext())
+    if (FirebaseApp.getApps(ApplicationProvider.getApplicationContext()).isEmpty()) {
+      FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
     }
 
     mockAuth = mock(FirebaseAuth::class.java)
+    mockFirestore = mock(FirebaseFirestore::class.java)
+    mockCollectionRef = mock(CollectionReference::class.java)
+    mockQuery = mock(Query::class.java)
 
-    repository = RegisterRepositoryFirestore(mockAuth)
+    // For any username passed to whereEqualTo, return mockQuery
+    `when`(mockFirestore.collection("users")).thenReturn(mockCollectionRef)
+    `when`(mockCollectionRef.whereEqualTo(eq("username"), anyString())).thenReturn(mockQuery)
+    `when`(mockQuery.limit(1)).thenReturn(mockQuery)
+
+    repository = RegisterRepositoryFirestore(mockAuth, mockFirestore)
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
   }
 
   @Test
-  fun `registerUser succeeds with valid credentials`() = runBlocking {
+  fun `registerUser throws UsernameAlreadyExistsException when username is taken`() = runTest {
     val mockResult = mock(AuthResult::class.java)
+    val mockQuerySnapshot = mock(QuerySnapshot::class.java)
+    val mockDoc = mock(DocumentSnapshot::class.java)
+
+    // Query should not be empty for "takenUsername"
+    `when`(mockQuerySnapshot.isEmpty).thenReturn(false)
+    `when`(mockQuerySnapshot.documents).thenReturn(listOf(mockDoc))
+    `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+
     `when`(mockAuth.createUserWithEmailAndPassword("test@example.com", "Password123"))
         .thenReturn(Tasks.forResult(mockResult))
 
     try {
-      repository.registerUser("test@example.com", "Password123")
-      assertTrue(true)
+      repository.registerUser("test@example.com", "Password123", "takenUsername")
+      fail("Expected UsernameAlreadyExistsException to be thrown")
+    } catch (e: UsernameAlreadyExistsException) {
+      assertEquals("Username 'takenUsername' is already in use.", e.message)
     } catch (e: Exception) {
-      fail("Expected registration to succeed, but it failed with exception: ${e.message}")
+      fail("Expected UsernameAlreadyExistsException, but got ${e::class.simpleName}")
     }
   }
 
   @Test
-  fun `registerUser throws UserAlreadyExistsException when email is already in use`() =
-      runBlocking {
-        val exception =
-            FirebaseAuthUserCollisionException(
-                "ERROR_EMAIL_ALREADY_IN_USE",
-                "The email address is already in use by another account.")
-        `when`(mockAuth.createUserWithEmailAndPassword("test@example.com", "Password123"))
-            .thenReturn(Tasks.forException(exception))
+  fun `registerUser throws UserAlreadyExistsException when email is already in use`() = runTest {
+    val mockQuerySnapshot = mock(QuerySnapshot::class.java)
+    `when`(mockQuerySnapshot.isEmpty).thenReturn(true)
+    `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
 
-        try {
-          repository.registerUser("test@example.com", "Password123")
-          fail("Expected UserAlreadyExistsException to be thrown")
-        } catch (e: UserAlreadyExistsException) {
-          assertEquals("An account with this email already exists.", e.message)
-        } catch (e: Exception) {
-          fail("Expected UserAlreadyExistsException, but got ${e::class.simpleName}")
-        }
-      }
+    val exception =
+        FirebaseAuthUserCollisionException(
+            "ERROR_EMAIL_ALREADY_IN_USE", "The email address is already in use by another account.")
+
+    `when`(mockAuth.createUserWithEmailAndPassword("test@example.com", "Password123"))
+        .thenReturn(Tasks.forException(exception))
+
+    try {
+      repository.registerUser("test@example.com", "Password123", "anotherUniqueUsername")
+      fail("Expected UserAlreadyExistsException to be thrown")
+    } catch (e: UserAlreadyExistsException) {
+      assertEquals("An account with this email already exists.", e.message)
+    } catch (e: Exception) {
+      fail("Expected UserAlreadyExistsException, but got ${e::class.simpleName}")
+    }
+  }
 
   @Test
-  fun `registerUser throws WeakPasswordException when password is weak`() = runBlocking {
+  fun `registerUser throws WeakPasswordException when password is weak`() = runTest {
+    val mockQuerySnapshot = mock(QuerySnapshot::class.java)
+    `when`(mockQuerySnapshot.isEmpty).thenReturn(true)
+    `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+
     val exception =
         FirebaseAuthWeakPasswordException("ERROR_WEAK_PASSWORD", "Password is too weak", null)
+
     `when`(mockAuth.createUserWithEmailAndPassword("test@example.com", "weakpass"))
         .thenReturn(Tasks.forException(exception))
 
     try {
-      repository.registerUser("test@example.com", "weakpass")
+      repository.registerUser("test@example.com", "weakpass", "weakPassUsername")
       fail("Expected WeakPasswordException to be thrown")
     } catch (e: WeakPasswordException) {
       assertEquals("Your password is too weak.", e.message)
@@ -84,13 +123,18 @@ class RegisterRepositoryFirestoreTest {
   }
 
   @Test
-  fun `registerUser throws Exception for unknown errors`() = runBlocking {
+  fun `registerUser throws Exception for unknown errors`() = runTest {
+    val mockQuerySnapshot = mock(QuerySnapshot::class.java)
+    `when`(mockQuerySnapshot.isEmpty).thenReturn(true)
+    `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+
     val exception = Exception("Unknown error")
+
     `when`(mockAuth.createUserWithEmailAndPassword("test@example.com", "Password123"))
         .thenReturn(Tasks.forException(exception))
 
     try {
-      repository.registerUser("test@example.com", "Password123")
+      repository.registerUser("test@example.com", "Password123", "errorUsername")
       fail("Expected Exception to be thrown")
     } catch (e: Exception) {
       assertEquals("Registration failed due to an unexpected error.", e.message)


### PR DESCRIPTION
This pull request introduces distinct username validation into the user registration flow, ensuring that no two users can share the same username.

**Key Changes:**
- **New Feature:**
  - Introduce `UsernameAlreadyExistsException` to handle scenarios where the chosen username is already taken.
  - Update `RegisterRepository` and `RegisterRepositoryFirestore` to query Firestore for existing usernames before creating a user.
  - Extend `RegisterState` and `RegisterViewModel` to support username fields and validation logic.
  - Enhance the registration UI (`Register.kt`) with a username input field and proper error handling.

- **Tests:**
  - Add and refine tests in `RegisterViewModelTest` and `RegisterRepositoryFirestoreTest` to cover username uniqueness checks and related exceptions.
  - Update UI tests (`RegisterKtTest`) to verify the presence and correct behavior of the username field.

By merging this PR, we ensure that the registration process provides immediate feedback on username availability, improving both user experience and data integrity.