### PR TITLE
Implement offline mode handling

### DIFF
--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/map/MapKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/map/MapKtTest.kt
@@ -78,7 +78,6 @@ class MapKtTest {
         .assertIsDisplayed()
   }
 
-
   @Test
   fun testNavigationToFeedBlockedForLoggedOutUser() {
     // Simulate offline mode
@@ -93,5 +92,4 @@ class MapKtTest {
     // Verify that navigation to the Sky Map is never triggered
     verify(mockNavigationActions, never()).navigateTo(Screen.SKY_MAP)
   }
-
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/map/MapKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/map/MapKtTest.kt
@@ -5,8 +5,12 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.lookupgroup27.lookup.R
 import com.github.lookupgroup27.lookup.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
+import com.github.lookupgroup27.lookup.ui.navigation.Screen
+import com.github.lookupgroup27.lookup.util.NetworkUtils
 import io.github.kakaocup.kakao.common.utilities.getResourceString
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import org.junit.*
 import org.mockito.kotlin.*
 
@@ -73,4 +77,21 @@ class MapKtTest {
         .onNodeWithTag(getResourceString(R.string.map_slider_test_tag))
         .assertIsDisplayed()
   }
+
+
+  @Test
+  fun testNavigationToFeedBlockedForLoggedOutUser() {
+    // Simulate offline mode
+    mockkObject(NetworkUtils)
+    every { NetworkUtils.isNetworkAvailable(any()) } returns false
+    // Simulate clicking the sky map tab in the bottom navigation
+    composeTestRule.onNodeWithTag("Sky Map").performClick()
+
+    // Wait for the UI to settle after the click
+    composeTestRule.waitForIdle()
+
+    // Verify that navigation to the Sky Map is never triggered
+    verify(mockNavigationActions, never()).navigateTo(Screen.SKY_MAP)
+  }
+
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/map/MapKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/map/MapKtTest.kt
@@ -79,7 +79,7 @@ class MapKtTest {
   }
 
   @Test
-  fun testNavigationToFeedBlockedForLoggedOutUser() {
+  fun testNavigationToSkyMapBlockedForOfflineMode() {
     // Simulate offline mode
     mockkObject(NetworkUtils)
     every { NetworkUtils.isNetworkAvailable(any()) } returns false

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/LandingKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/LandingKtTest.kt
@@ -153,9 +153,8 @@ class LandingKtTest {
 
     composeTestRule.setContent {
       LandingScreen(
-        navigationActions = mockNavigationActions,
-        toastHelper = mockToastHelper  // Pass the mock
-      )
+          navigationActions = mockNavigationActions, toastHelper = mockToastHelper // Pass the mock
+          )
     }
 
     // Click the background

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/LandingKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/LandingKtTest.kt
@@ -21,9 +21,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.never
-
+import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
 class LandingKtTest {
@@ -58,7 +57,7 @@ class LandingKtTest {
   @Test
   fun backgroundIsClickableAndNavigatesToMap() {
 
-    //simulate online mode
+    // simulate online mode
     simulateOnlineMode(true)
     composeTestRule.setContent { LandingScreen(mockNavigationActions) }
 

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/LandingKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/LandingKtTest.kt
@@ -14,6 +14,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
 import com.github.lookupgroup27.lookup.ui.navigation.Screen
+import com.github.lookupgroup27.lookup.util.ToastHelper
 import com.github.lookupgroup27.lookup.utils.TestNetworkUtils.simulateOnlineMode
 import org.junit.After
 import org.junit.Before
@@ -139,6 +140,31 @@ class LandingKtTest {
     composeTestRule.waitForIdle()
 
     // Verify that navigation to the Sky Map is never triggered
+    verify(mockNavigationActions, never()).navigateTo(Screen.SKY_MAP)
+  }
+
+  @Test
+  fun landingScreen_showsToastWhenClickingBackground() {
+    // Mock the toast helper
+    val mockToastHelper = mock<ToastHelper>()
+
+    // Simulate offline mode
+    simulateOnlineMode(false)
+
+    composeTestRule.setContent {
+      LandingScreen(
+        navigationActions = mockNavigationActions,
+        toastHelper = mockToastHelper  // Pass the mock
+      )
+    }
+
+    // Click the background
+    composeTestRule.onNodeWithTag("LandingScreen").performClick()
+
+    // Verify toast was shown
+    verify(mockToastHelper).showNoInternetToast()
+
+    // Verify no navigation occurred
     verify(mockNavigationActions, never()).navigateTo(Screen.SKY_MAP)
   }
 

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/LandingKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/LandingKtTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
@@ -13,6 +14,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
 import com.github.lookupgroup27.lookup.ui.navigation.Screen
+import com.github.lookupgroup27.lookup.utils.TestNetworkUtils.simulateOnlineMode
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -20,6 +22,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.never
+
 
 @RunWith(AndroidJUnit4::class)
 class LandingKtTest {
@@ -53,6 +57,9 @@ class LandingKtTest {
 
   @Test
   fun backgroundIsClickableAndNavigatesToMap() {
+
+    //simulate online mode
+    simulateOnlineMode(true)
     composeTestRule.setContent { LandingScreen(mockNavigationActions) }
 
     // Verify that the background image is displayed and clickable
@@ -114,6 +121,26 @@ class LandingKtTest {
 
     // Reset orientation to portrait after the test
     resetOrientation()
+  }
+
+  @Test
+  fun testBackgroundClickDoesNotNavigateToMapWhenOffline() {
+    // Simulate offline mode
+    simulateOnlineMode(false)
+
+    composeTestRule.setContent { LandingScreen(mockNavigationActions) }
+
+    // Verify the background is clickable
+    composeTestRule.onNodeWithTag("LandingScreen").assertHasClickAction()
+
+    // Perform a click action on the background
+    composeTestRule.onNodeWithTag("LandingScreen").performClick()
+
+    // Wait for the UI to settle after the click
+    composeTestRule.waitForIdle()
+
+    // Verify that navigation to the Sky Map is never triggered
+    verify(mockNavigationActions, never()).navigateTo(Screen.SKY_MAP)
   }
 
   private fun setLandscapeOrientation() {

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/MenuKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/MenuKtTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.lookupgroup27.lookup.model.profile.ProfileRepository
 import com.github.lookupgroup27.lookup.ui.navigation.*
 import com.github.lookupgroup27.lookup.ui.profile.profilepic.AvatarViewModel
+import com.github.lookupgroup27.lookup.util.ToastHelper
 import com.github.lookupgroup27.lookup.utils.TestNetworkUtils.simulateOnlineMode
 import com.google.firebase.auth.FirebaseAuth
 import org.junit.*
@@ -192,6 +193,32 @@ class MenuKtTest {
     composeTestRule.onNodeWithText("Google Map").performClick()
 
     // Verify no navigation to Google Map screen is triggered
+    verify(mockNavigationActions, never()).navigateTo(Screen.GOOGLE_MAP)
+  }
+
+  @Test
+  fun menuScreen_showsToastWhenClickingGoogleMapButtonOffline() {
+    // Mock the toast helper
+    val mockToastHelper = mock<ToastHelper>()
+
+    // Simulate offline mode
+    simulateOnlineMode(false)
+
+    composeTestRule.setContent {
+      MenuScreen(
+        navigationActions = mockNavigationActions,
+        avatarViewModel = mockAvatarViewModel,
+        toastHelper = mockToastHelper
+      )
+    }
+
+    // Click the Google Map button
+    composeTestRule.onNodeWithText("Google Map").performClick()
+
+    // Verify toast was shown
+    verify(mockToastHelper).showNoInternetToast()
+
+    // Verify no navigation occurred
     verify(mockNavigationActions, never()).navigateTo(Screen.GOOGLE_MAP)
   }
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/MenuKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/MenuKtTest.kt
@@ -5,9 +5,11 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.lookupgroup27.lookup.model.profile.ProfileRepository
 import com.github.lookupgroup27.lookup.ui.navigation.*
 import com.github.lookupgroup27.lookup.ui.profile.profilepic.AvatarViewModel
+import com.github.lookupgroup27.lookup.utils.TestNetworkUtils.simulateOnlineMode
 import com.google.firebase.auth.FirebaseAuth
 import org.junit.*
 import org.mockito.kotlin.*
+
 
 class MenuKtTest {
 
@@ -56,6 +58,8 @@ class MenuKtTest {
 
   @Test
   fun menuScreen_bottomNavigation_clickMapTab_navigatesToMap() {
+    //simulate online mode
+    simulateOnlineMode(true)
     composeTestRule.setContent {
       MenuScreen(navigationActions = mockNavigationActions, mockAvatarViewModel)
     }
@@ -130,6 +134,8 @@ class MenuKtTest {
 
   @Test
   fun menuScreen_clickCalendar_navigatesToCalendarScreen() {
+    //simulate online mode
+    simulateOnlineMode(true)
     composeTestRule.setContent {
       MenuScreen(navigationActions = mockNavigationActions, mockAvatarViewModel)
     }
@@ -143,6 +149,8 @@ class MenuKtTest {
 
   @Test
   fun menuScreen_clickGoogleMap_navigatesToGoogleMapScreen() {
+    //simulate online mode
+    simulateOnlineMode(true)
     composeTestRule.setContent {
       MenuScreen(navigationActions = mockNavigationActions, mockAvatarViewModel)
     }
@@ -166,4 +174,25 @@ class MenuKtTest {
     // Verify navigation to PlanetSelection screen is triggered
     verify(mockNavigationActions).navigateTo(Screen.PLANET_SELECTION)
   }
-}
+
+  @Test
+  fun menuScreen_otherButtons_areDisabledWhenOffline() {
+    // Simulate offline mode
+    simulateOnlineMode(false)
+
+    composeTestRule.setContent {
+      MenuScreen(navigationActions = mockNavigationActions, mockAvatarViewModel)
+    }
+    // Attempt to click the "Calendar" button and verify no navigation
+    composeTestRule.onNodeWithText("Calendar").performClick()
+
+    // Verify no navigation to the Calendar screen occurred
+    verify(mockNavigationActions, never()).navigateTo(Screen.CALENDAR)
+
+    // Attempt to click the "Google Map" button and verify no navigation
+    composeTestRule.onNodeWithText("Google Map").performClick()
+
+    // Verify no navigation to Google Map screen is triggered
+    verify(mockNavigationActions, never()).navigateTo(Screen.GOOGLE_MAP)
+
+  }   }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/MenuKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/MenuKtTest.kt
@@ -206,10 +206,9 @@ class MenuKtTest {
 
     composeTestRule.setContent {
       MenuScreen(
-        navigationActions = mockNavigationActions,
-        avatarViewModel = mockAvatarViewModel,
-        toastHelper = mockToastHelper
-      )
+          navigationActions = mockNavigationActions,
+          avatarViewModel = mockAvatarViewModel,
+          toastHelper = mockToastHelper)
     }
 
     // Click the Google Map button
@@ -232,10 +231,9 @@ class MenuKtTest {
 
     composeTestRule.setContent {
       MenuScreen(
-        navigationActions = mockNavigationActions,
-        avatarViewModel = mockAvatarViewModel,
-        toastHelper = mockToastHelper
-      )
+          navigationActions = mockNavigationActions,
+          avatarViewModel = mockAvatarViewModel,
+          toastHelper = mockToastHelper)
     }
 
     // Click the Calendar button

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/MenuKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/MenuKtTest.kt
@@ -10,7 +10,6 @@ import com.google.firebase.auth.FirebaseAuth
 import org.junit.*
 import org.mockito.kotlin.*
 
-
 class MenuKtTest {
 
   @get:Rule val composeTestRule = createComposeRule()
@@ -58,7 +57,7 @@ class MenuKtTest {
 
   @Test
   fun menuScreen_bottomNavigation_clickMapTab_navigatesToMap() {
-    //simulate online mode
+    // simulate online mode
     simulateOnlineMode(true)
     composeTestRule.setContent {
       MenuScreen(navigationActions = mockNavigationActions, mockAvatarViewModel)
@@ -134,7 +133,7 @@ class MenuKtTest {
 
   @Test
   fun menuScreen_clickCalendar_navigatesToCalendarScreen() {
-    //simulate online mode
+    // simulate online mode
     simulateOnlineMode(true)
     composeTestRule.setContent {
       MenuScreen(navigationActions = mockNavigationActions, mockAvatarViewModel)
@@ -149,7 +148,7 @@ class MenuKtTest {
 
   @Test
   fun menuScreen_clickGoogleMap_navigatesToGoogleMapScreen() {
-    //simulate online mode
+    // simulate online mode
     simulateOnlineMode(true)
     composeTestRule.setContent {
       MenuScreen(navigationActions = mockNavigationActions, mockAvatarViewModel)
@@ -194,5 +193,5 @@ class MenuKtTest {
 
     // Verify no navigation to Google Map screen is triggered
     verify(mockNavigationActions, never()).navigateTo(Screen.GOOGLE_MAP)
-
-  }   }
+  }
+}

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/MenuKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/MenuKtTest.kt
@@ -221,4 +221,30 @@ class MenuKtTest {
     // Verify no navigation occurred
     verify(mockNavigationActions, never()).navigateTo(Screen.GOOGLE_MAP)
   }
+
+  @Test
+  fun menuScreen_showsToastWhenClickingCalendarOffline() {
+    // Mock the toast helper
+    val mockToastHelper = mock<ToastHelper>()
+
+    // Simulate offline mode
+    simulateOnlineMode(false)
+
+    composeTestRule.setContent {
+      MenuScreen(
+        navigationActions = mockNavigationActions,
+        avatarViewModel = mockAvatarViewModel,
+        toastHelper = mockToastHelper
+      )
+    }
+
+    // Click the Calendar button
+    composeTestRule.onNodeWithText("Calendar").performClick()
+
+    // Verify toast was shown
+    verify(mockToastHelper).showNoInternetToast()
+
+    // Verify no navigation occurred
+    verify(mockNavigationActions, never()).navigateTo(Screen.CALENDAR)
+  }
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/utils/TestNetworkuUtils.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/utils/TestNetworkuUtils.kt
@@ -1,6 +1,5 @@
 package com.github.lookupgroup27.lookup.utils
 
-
 import com.github.lookupgroup27.lookup.util.NetworkUtils
 import io.mockk.every
 import io.mockk.mockkObject
@@ -13,15 +12,15 @@ import io.mockk.mockkObject
  */
 object TestNetworkUtils {
 
-    /**
-     * Simulates network connectivity state for tests.
-     *
-     * @param onlineState A boolean indicating the desired network connectivity state:
-     *     - `true` to simulate online mode
-     *     - `false` to simulate offline mode
-     */
-    fun simulateOnlineMode(onlineState: Boolean) {
-        mockkObject(NetworkUtils)
-        every { NetworkUtils.isNetworkAvailable(any()) } returns onlineState
-    }
+  /**
+   * Simulates network connectivity state for tests.
+   *
+   * @param onlineState A boolean indicating the desired network connectivity state:
+   *     - `true` to simulate online mode
+   *     - `false` to simulate offline mode
+   */
+  fun simulateOnlineMode(onlineState: Boolean) {
+    mockkObject(NetworkUtils)
+    every { NetworkUtils.isNetworkAvailable(any()) } returns onlineState
+  }
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/utils/TestNetworkuUtils.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/utils/TestNetworkuUtils.kt
@@ -1,0 +1,27 @@
+package com.github.lookupgroup27.lookup.utils
+
+
+import com.github.lookupgroup27.lookup.util.NetworkUtils
+import io.mockk.every
+import io.mockk.mockkObject
+
+/**
+ * Test utility class to simulate online/offline modes.
+ *
+ * This class provides a function to mock network connectivity states, allowing tests to simulate
+ * conditions where the device is either online or offline.
+ */
+object TestNetworkUtils {
+
+    /**
+     * Simulates network connectivity state for tests.
+     *
+     * @param onlineState A boolean indicating the desired network connectivity state:
+     *     - `true` to simulate online mode
+     *     - `false` to simulate offline mode
+     */
+    fun simulateOnlineMode(onlineState: Boolean) {
+        mockkObject(NetworkUtils)
+        every { NetworkUtils.isNetworkAvailable(any()) } returns onlineState
+    }
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/BottomNavigationMenu.kt
@@ -19,6 +19,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import com.github.lookupgroup27.lookup.util.NetworkUtils
 
 @Composable
 fun BottomNavigationMenu(
@@ -28,6 +31,7 @@ fun BottomNavigationMenu(
     selectedItem: String
 ) {
   val context = LocalContext.current
+    val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
   NavigationBar(
       modifier = Modifier.fillMaxWidth().height(60.dp).testTag("bottomNavigationMenu"),
       containerColor = Color(0xFF0D1023),
@@ -53,13 +57,21 @@ fun BottomNavigationMenu(
               label = { Text(text = tab.textId, color = Color.White) },
               selected = tab.route == selectedItem,
               onClick = {
-                if (tab.route == Route.FEED && !isUserLoggedIn) {
-                  Toast.makeText(
-                          context, "You need to log in to access the feed.", Toast.LENGTH_LONG)
-                      .show()
-                } else if (selectedItem != tab.route) {
-                  onTabSelect(tab)
-                }
+                  when {
+                      tab.route == Route.FEED && !isUserLoggedIn -> {
+                          Toast.makeText(
+                              context, "You need to log in to access the feed.", Toast.LENGTH_LONG)
+                              .show()
+                      }
+                      tab.route == Route.SKY_MAP && !isOnline.value -> {
+                          Toast.makeText(
+                              context, "You're not connected to the internet.", Toast.LENGTH_LONG)
+                              .show()
+                      }
+                      selectedItem != tab.route -> {
+                          onTabSelect(tab)
+                      }
+                  }
               },
               modifier = Modifier.clip(shape = RoundedCornerShape(50.dp)).testTag(tab.textId))
         }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/BottomNavigationMenu.kt
@@ -31,7 +31,7 @@ fun BottomNavigationMenu(
     isUserLoggedIn: Boolean,
     selectedItem: String
 ) {
-    val  toastHelper: ToastHelper = ToastHelper(LocalContext.current)
+  val toastHelper: ToastHelper = ToastHelper(LocalContext.current)
   val context = LocalContext.current
   val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
   NavigationBar(
@@ -66,7 +66,7 @@ fun BottomNavigationMenu(
                         .show()
                   }
                   tab.route == Route.SKY_MAP && !isOnline.value -> {
-                      toastHelper.showNoInternetToast()
+                    toastHelper.showNoInternetToast()
                   }
                   selectedItem != tab.route -> {
                     onTabSelect(tab)

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/BottomNavigationMenu.kt
@@ -11,6 +11,8 @@ import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -19,8 +21,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import com.github.lookupgroup27.lookup.util.NetworkUtils
 
 @Composable
@@ -31,7 +31,7 @@ fun BottomNavigationMenu(
     selectedItem: String
 ) {
   val context = LocalContext.current
-    val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
+  val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
   NavigationBar(
       modifier = Modifier.fillMaxWidth().height(60.dp).testTag("bottomNavigationMenu"),
       containerColor = Color(0xFF0D1023),
@@ -57,21 +57,21 @@ fun BottomNavigationMenu(
               label = { Text(text = tab.textId, color = Color.White) },
               selected = tab.route == selectedItem,
               onClick = {
-                  when {
-                      tab.route == Route.FEED && !isUserLoggedIn -> {
-                          Toast.makeText(
-                              context, "You need to log in to access the feed.", Toast.LENGTH_LONG)
-                              .show()
-                      }
-                      tab.route == Route.SKY_MAP && !isOnline.value -> {
-                          Toast.makeText(
-                              context, "You're not connected to the internet.", Toast.LENGTH_LONG)
-                              .show()
-                      }
-                      selectedItem != tab.route -> {
-                          onTabSelect(tab)
-                      }
+                when {
+                  tab.route == Route.FEED && !isUserLoggedIn -> {
+                    Toast.makeText(
+                            context, "You need to log in to access the feed.", Toast.LENGTH_LONG)
+                        .show()
                   }
+                  tab.route == Route.SKY_MAP && !isOnline.value -> {
+                    Toast.makeText(
+                            context, "You're not connected to the internet.", Toast.LENGTH_LONG)
+                        .show()
+                  }
+                  selectedItem != tab.route -> {
+                    onTabSelect(tab)
+                  }
+                }
               },
               modifier = Modifier.clip(shape = RoundedCornerShape(50.dp)).testTag(tab.textId))
         }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/BottomNavigationMenu.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.github.lookupgroup27.lookup.util.NetworkUtils
+import com.github.lookupgroup27.lookup.util.ToastHelper
 
 @Composable
 fun BottomNavigationMenu(
@@ -30,6 +31,7 @@ fun BottomNavigationMenu(
     isUserLoggedIn: Boolean,
     selectedItem: String
 ) {
+    val  toastHelper: ToastHelper = ToastHelper(LocalContext.current)
   val context = LocalContext.current
   val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
   NavigationBar(
@@ -64,9 +66,7 @@ fun BottomNavigationMenu(
                         .show()
                   }
                   tab.route == Route.SKY_MAP && !isOnline.value -> {
-                    Toast.makeText(
-                            context, "You're not connected to the internet.", Toast.LENGTH_LONG)
-                        .show()
+                      toastHelper.showNoInternetToast()
                   }
                   selectedItem != tab.route -> {
                     onTabSelect(tab)

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Landing.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Landing.kt
@@ -1,7 +1,6 @@
 package com.github.lookupgroup27.lookup.ui.overview
 
 import android.annotation.SuppressLint
-import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -37,19 +36,20 @@ import components.BackgroundImage
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
-fun LandingScreen(navigationActions: NavigationActions,toastHelper: ToastHelper = ToastHelper(LocalContext.current)) {
+fun LandingScreen(
+    navigationActions: NavigationActions,
+    toastHelper: ToastHelper = ToastHelper(LocalContext.current)
+) {
 
   val context = LocalContext.current
   val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
-
 
   // Background container with clickable modifier to navigate to Map screen
   BoxWithConstraints(
       modifier =
           Modifier.fillMaxSize().testTag("LandingScreen").clickable {
             if (isOnline.value) navigationActions.navigateTo(Screen.SKY_MAP)
-            else
-                toastHelper.showNoInternetToast()
+            else toastHelper.showNoInternetToast()
           }) {
         // Background Image
         BackgroundImage(

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Landing.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Landing.kt
@@ -32,14 +32,16 @@ import com.github.lookupgroup27.lookup.R
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
 import com.github.lookupgroup27.lookup.ui.navigation.Screen
 import com.github.lookupgroup27.lookup.util.NetworkUtils
+import com.github.lookupgroup27.lookup.util.ToastHelper
 import components.BackgroundImage
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
-fun LandingScreen(navigationActions: NavigationActions) {
+fun LandingScreen(navigationActions: NavigationActions,toastHelper: ToastHelper = ToastHelper(LocalContext.current)) {
 
   val context = LocalContext.current
   val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
+
 
   // Background container with clickable modifier to navigate to Map screen
   BoxWithConstraints(
@@ -47,8 +49,7 @@ fun LandingScreen(navigationActions: NavigationActions) {
           Modifier.fillMaxSize().testTag("LandingScreen").clickable {
             if (isOnline.value) navigationActions.navigateTo(Screen.SKY_MAP)
             else
-                Toast.makeText(context, "You're not connected to the internet", Toast.LENGTH_SHORT)
-                    .show()
+                toastHelper.showNoInternetToast()
           }) {
         // Background Image
         BackgroundImage(

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Landing.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Landing.kt
@@ -1,6 +1,7 @@
 package com.github.lookupgroup27.lookup.ui.overview
 
 import android.annotation.SuppressLint
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -12,10 +13,13 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -27,28 +31,24 @@ import androidx.navigation.compose.rememberNavController
 import com.github.lookupgroup27.lookup.R
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
 import com.github.lookupgroup27.lookup.ui.navigation.Screen
-import components.BackgroundImage
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import android.widget.Toast
-import androidx.compose.ui.platform.LocalContext
 import com.github.lookupgroup27.lookup.util.NetworkUtils
+import components.BackgroundImage
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 fun LandingScreen(navigationActions: NavigationActions) {
 
-    val context = LocalContext.current
-    val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
+  val context = LocalContext.current
+  val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
 
   // Background container with clickable modifier to navigate to Map screen
   BoxWithConstraints(
       modifier =
           Modifier.fillMaxSize().testTag("LandingScreen").clickable {
-              if (isOnline.value) navigationActions.navigateTo(Screen.SKY_MAP)
-              else
-                  Toast.makeText(context, "You're not connected to the internet", Toast.LENGTH_SHORT)
-                      .show()
+            if (isOnline.value) navigationActions.navigateTo(Screen.SKY_MAP)
+            else
+                Toast.makeText(context, "You're not connected to the internet", Toast.LENGTH_SHORT)
+                    .show()
           }) {
         // Background Image
         BackgroundImage(

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Landing.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Landing.kt
@@ -28,15 +28,27 @@ import com.github.lookupgroup27.lookup.R
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
 import com.github.lookupgroup27.lookup.ui.navigation.Screen
 import components.BackgroundImage
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import android.widget.Toast
+import androidx.compose.ui.platform.LocalContext
+import com.github.lookupgroup27.lookup.util.NetworkUtils
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 fun LandingScreen(navigationActions: NavigationActions) {
+
+    val context = LocalContext.current
+    val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
+
   // Background container with clickable modifier to navigate to Map screen
   BoxWithConstraints(
       modifier =
           Modifier.fillMaxSize().testTag("LandingScreen").clickable {
-            navigationActions.navigateTo(Screen.SKY_MAP)
+              if (isOnline.value) navigationActions.navigateTo(Screen.SKY_MAP)
+              else
+                  Toast.makeText(context, "You're not connected to the internet", Toast.LENGTH_SHORT)
+                      .show()
           }) {
         // Background Image
         BackgroundImage(

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Menu.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Menu.kt
@@ -1,6 +1,7 @@
 package com.github.lookupgroup27.lookup.ui.overview
 
 import android.annotation.SuppressLint
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -13,6 +14,7 @@ import androidx.compose.ui.*
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -20,10 +22,8 @@ import androidx.compose.ui.unit.dp
 import com.github.lookupgroup27.lookup.R
 import com.github.lookupgroup27.lookup.ui.navigation.*
 import com.github.lookupgroup27.lookup.ui.profile.profilepic.AvatarViewModel
-import com.google.firebase.auth.FirebaseAuth
 import com.github.lookupgroup27.lookup.util.NetworkUtils
-import androidx.compose.ui.platform.LocalContext
-import android.widget.Toast
+import com.google.firebase.auth.FirebaseAuth
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
@@ -34,9 +34,8 @@ fun MenuScreen(navigationActions: NavigationActions, avatarViewModel: AvatarView
 
   val userId = auth.currentUser?.uid.orEmpty()
 
-
-    val context = LocalContext.current
-    val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
+  val context = LocalContext.current
+  val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
 
   // Fetch the selected avatar for the logged-in user
   val selectedAvatar by avatarViewModel.selectedAvatar.collectAsState(initial = null)
@@ -111,16 +110,16 @@ fun MenuScreen(navigationActions: NavigationActions, avatarViewModel: AvatarView
                     }
                 Spacer(modifier = Modifier.height(8.dp))
 
-              // Blocked buttons when offline
+                // Blocked buttons when offline
                 Button(
                     onClick = {
-                        if (isOnline.value) navigationActions.navigateTo(Screen.CALENDAR)
-                        else
-                            Toast.makeText(
-                                context,
-                                "You're not connected to the internet",
-                                Toast.LENGTH_SHORT)
-                                .show()
+                      if (isOnline.value) navigationActions.navigateTo(Screen.CALENDAR)
+                      else
+                          Toast.makeText(
+                                  context,
+                                  "You're not connected to the internet",
+                                  Toast.LENGTH_SHORT)
+                              .show()
                     },
                     enabled = isOnline.value,
                     modifier = Modifier.fillMaxWidth(0.6f)) {
@@ -133,13 +132,13 @@ fun MenuScreen(navigationActions: NavigationActions, avatarViewModel: AvatarView
 
                 Button(
                     onClick = {
-                        if (isOnline.value) navigationActions.navigateTo(Screen.GOOGLE_MAP)
-                        else
-                            Toast.makeText(
-                                context,
-                                "You're not connected to the internet",
-                                Toast.LENGTH_SHORT)
-                                .show()
+                      if (isOnline.value) navigationActions.navigateTo(Screen.GOOGLE_MAP)
+                      else
+                          Toast.makeText(
+                                  context,
+                                  "You're not connected to the internet",
+                                  Toast.LENGTH_SHORT)
+                              .show()
                     },
                     enabled = isOnline.value,
                     modifier = Modifier.fillMaxWidth(0.6f)) {

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Menu.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Menu.kt
@@ -23,11 +23,12 @@ import com.github.lookupgroup27.lookup.R
 import com.github.lookupgroup27.lookup.ui.navigation.*
 import com.github.lookupgroup27.lookup.ui.profile.profilepic.AvatarViewModel
 import com.github.lookupgroup27.lookup.util.NetworkUtils
+import com.github.lookupgroup27.lookup.util.ToastHelper
 import com.google.firebase.auth.FirebaseAuth
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun MenuScreen(navigationActions: NavigationActions, avatarViewModel: AvatarViewModel) {
+fun MenuScreen(navigationActions: NavigationActions, avatarViewModel: AvatarViewModel, toastHelper: ToastHelper = ToastHelper(LocalContext.current) ) {
 
   val auth = remember { FirebaseAuth.getInstance() }
   val isLoggedIn = auth.currentUser != null
@@ -115,13 +116,8 @@ fun MenuScreen(navigationActions: NavigationActions, avatarViewModel: AvatarView
                     onClick = {
                       if (isOnline.value) navigationActions.navigateTo(Screen.CALENDAR)
                       else
-                          Toast.makeText(
-                                  context,
-                                  "You're not connected to the internet",
-                                  Toast.LENGTH_SHORT)
-                              .show()
+                          toastHelper.showNoInternetToast()
                     },
-                    enabled = isOnline.value,
                     modifier = Modifier.fillMaxWidth(0.6f)) {
                       Text(
                           text = "Calendar",
@@ -134,13 +130,8 @@ fun MenuScreen(navigationActions: NavigationActions, avatarViewModel: AvatarView
                     onClick = {
                       if (isOnline.value) navigationActions.navigateTo(Screen.GOOGLE_MAP)
                       else
-                          Toast.makeText(
-                                  context,
-                                  "You're not connected to the internet",
-                                  Toast.LENGTH_SHORT)
-                              .show()
+                          toastHelper.showNoInternetToast()
                     },
-                    enabled = isOnline.value,
                     modifier = Modifier.fillMaxWidth(0.6f)) {
                       Text(
                           text = "Google Map",

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Menu.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Menu.kt
@@ -1,7 +1,6 @@
 package com.github.lookupgroup27.lookup.ui.overview
 
 import android.annotation.SuppressLint
-import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -28,7 +27,11 @@ import com.google.firebase.auth.FirebaseAuth
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun MenuScreen(navigationActions: NavigationActions, avatarViewModel: AvatarViewModel, toastHelper: ToastHelper = ToastHelper(LocalContext.current) ) {
+fun MenuScreen(
+    navigationActions: NavigationActions,
+    avatarViewModel: AvatarViewModel,
+    toastHelper: ToastHelper = ToastHelper(LocalContext.current)
+) {
 
   val auth = remember { FirebaseAuth.getInstance() }
   val isLoggedIn = auth.currentUser != null
@@ -115,8 +118,7 @@ fun MenuScreen(navigationActions: NavigationActions, avatarViewModel: AvatarView
                 Button(
                     onClick = {
                       if (isOnline.value) navigationActions.navigateTo(Screen.CALENDAR)
-                      else
-                          toastHelper.showNoInternetToast()
+                      else toastHelper.showNoInternetToast()
                     },
                     modifier = Modifier.fillMaxWidth(0.6f)) {
                       Text(
@@ -129,8 +131,7 @@ fun MenuScreen(navigationActions: NavigationActions, avatarViewModel: AvatarView
                 Button(
                     onClick = {
                       if (isOnline.value) navigationActions.navigateTo(Screen.GOOGLE_MAP)
-                      else
-                          toastHelper.showNoInternetToast()
+                      else toastHelper.showNoInternetToast()
                     },
                     modifier = Modifier.fillMaxWidth(0.6f)) {
                       Text(

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Menu.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Menu.kt
@@ -21,6 +21,9 @@ import com.github.lookupgroup27.lookup.R
 import com.github.lookupgroup27.lookup.ui.navigation.*
 import com.github.lookupgroup27.lookup.ui.profile.profilepic.AvatarViewModel
 import com.google.firebase.auth.FirebaseAuth
+import com.github.lookupgroup27.lookup.util.NetworkUtils
+import androidx.compose.ui.platform.LocalContext
+import android.widget.Toast
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
@@ -30,6 +33,10 @@ fun MenuScreen(navigationActions: NavigationActions, avatarViewModel: AvatarView
   val isLoggedIn = auth.currentUser != null
 
   val userId = auth.currentUser?.uid.orEmpty()
+
+
+    val context = LocalContext.current
+    val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
 
   // Fetch the selected avatar for the logged-in user
   val selectedAvatar by avatarViewModel.selectedAvatar.collectAsState(initial = null)
@@ -104,8 +111,18 @@ fun MenuScreen(navigationActions: NavigationActions, avatarViewModel: AvatarView
                     }
                 Spacer(modifier = Modifier.height(8.dp))
 
+              // Blocked buttons when offline
                 Button(
-                    onClick = { navigationActions.navigateTo(Screen.CALENDAR) },
+                    onClick = {
+                        if (isOnline.value) navigationActions.navigateTo(Screen.CALENDAR)
+                        else
+                            Toast.makeText(
+                                context,
+                                "You're not connected to the internet",
+                                Toast.LENGTH_SHORT)
+                                .show()
+                    },
+                    enabled = isOnline.value,
                     modifier = Modifier.fillMaxWidth(0.6f)) {
                       Text(
                           text = "Calendar",
@@ -115,7 +132,16 @@ fun MenuScreen(navigationActions: NavigationActions, avatarViewModel: AvatarView
                 Spacer(modifier = Modifier.height(8.dp))
 
                 Button(
-                    onClick = { navigationActions.navigateTo(Screen.GOOGLE_MAP) },
+                    onClick = {
+                        if (isOnline.value) navigationActions.navigateTo(Screen.GOOGLE_MAP)
+                        else
+                            Toast.makeText(
+                                context,
+                                "You're not connected to the internet",
+                                Toast.LENGTH_SHORT)
+                                .show()
+                    },
+                    enabled = isOnline.value,
                     modifier = Modifier.fillMaxWidth(0.6f)) {
                       Text(
                           text = "Google Map",

--- a/app/src/main/java/com/github/lookupgroup27/lookup/util/NetworkUtils.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/util/NetworkUtils.kt
@@ -1,0 +1,16 @@
+package com.github.lookupgroup27.lookup.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+
+object NetworkUtils {
+    fun isNetworkAvailable(context: Context): Boolean {
+        val connectivityManager =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val activeNetwork = connectivityManager.activeNetwork ?: return false
+        val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/util/NetworkUtils.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/util/NetworkUtils.kt
@@ -4,13 +4,12 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 
-
 object NetworkUtils {
-    fun isNetworkAvailable(context: Context): Boolean {
-        val connectivityManager =
-            context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-        val activeNetwork = connectivityManager.activeNetwork ?: return false
-        val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork) ?: return false
-        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-    }
+  fun isNetworkAvailable(context: Context): Boolean {
+    val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    val activeNetwork = connectivityManager.activeNetwork ?: return false
+    val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork) ?: return false
+    return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+  }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/util/ToastHelper.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/util/ToastHelper.kt
@@ -4,17 +4,17 @@ import android.content.Context
 import android.widget.Toast
 
 /**
- * Helper class for displaying Toast messages throughout the application.
- * Encapsulates Toast creation logic for better testability and reusability.
+ * Helper class for displaying Toast messages throughout the application. Encapsulates Toast
+ * creation logic for better testability and reusability.
  *
  * @property context The Android Context used to display Toasts
  */
 open class ToastHelper(private val context: Context) {
-    /**
-     * Displays a short Toast message indicating no internet connection.
-     * Used when attempting network operations while offline.
-     */
-    open fun showNoInternetToast() {
-        Toast.makeText(context, "You're not connected to the internet", Toast.LENGTH_SHORT).show()
-    }
+  /**
+   * Displays a short Toast message indicating no internet connection. Used when attempting network
+   * operations while offline.
+   */
+  open fun showNoInternetToast() {
+    Toast.makeText(context, "You're not connected to the internet", Toast.LENGTH_SHORT).show()
+  }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/util/ToastHelper.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/util/ToastHelper.kt
@@ -3,8 +3,8 @@ package com.github.lookupgroup27.lookup.util
 import android.content.Context
 import android.widget.Toast
 
- class ToastHelper(private val context: Context) {
-    fun showNoInternetToast() {
+open class ToastHelper(private val context: Context) {
+    open fun showNoInternetToast() {
         Toast.makeText(context, "You're not connected to the internet", Toast.LENGTH_SHORT).show()
     }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/util/ToastHelper.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/util/ToastHelper.kt
@@ -1,0 +1,10 @@
+package com.github.lookupgroup27.lookup.util
+
+import android.content.Context
+import android.widget.Toast
+
+ class ToastHelper(private val context: Context) {
+    fun showNoInternetToast() {
+        Toast.makeText(context, "You're not connected to the internet", Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/java/com/github/lookupgroup27/lookup/util/ToastHelper.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/util/ToastHelper.kt
@@ -3,7 +3,17 @@ package com.github.lookupgroup27.lookup.util
 import android.content.Context
 import android.widget.Toast
 
+/**
+ * Helper class for displaying Toast messages throughout the application.
+ * Encapsulates Toast creation logic for better testability and reusability.
+ *
+ * @property context The Android Context used to display Toasts
+ */
 open class ToastHelper(private val context: Context) {
+    /**
+     * Displays a short Toast message indicating no internet connection.
+     * Used when attempting network operations while offline.
+     */
     open fun showNoInternetToast() {
         Toast.makeText(context, "You're not connected to the internet", Toast.LENGTH_SHORT).show()
     }


### PR DESCRIPTION
### Description

This PR implements offline mode functionality for the application by restricting access to specific features when the user is not connected to the internet. It ensures a seamless user experience by blocking unavailable features and providing clear feedback to the user.

### CI Explanation

During the initial PR, the CI behaved unpredictably due to lingering tests that were deleted but still persisted in the pipeline. Despite attempts to resolve the issue, it was deemed risky to clear caches or manipulate the CI further. To work around this, a new branch was created, and the exact same changes were replicated to bypass the CI's persistent issues. This approach ensures that the changes can be validated without unnecessary risk.

### Changes Made

#### Menu Screen:
- Restricted access to the Google Map and Calendar features when offline.
- Only the Quiz button remains functional in offline mode.
- Added a Toast message to notify the user that internet connectivity is required to access restricted features.

#### Landing Screen:
- The map navigation now checks for network connectivity.
- Displayed a Toast message when the user attempts to access the map offline.

#### Bottom Navigation Menu:
- Added logic to handle offline state.
- The Sky Map and Feed buttons now display a Toast message indicating that the internet is required when clicked offline.
- Ensures the UI reflects the network connectivity state.

#### NetworkUtils:
- Introduced a utility class to check network connectivity (`isNetworkAvailable`).

#### Tests:
- Added unit and UI tests to verify the offline behavior:
  - Menu screen button restrictions.
  - Bottom navigation button restrictions.
  - Landing screen navigation to sky map restrictions.

### Impact
- Improved user experience by clearly guiding users about the features unavailable offline.
- Ensured functionality aligns with offline mode requirements.

### Note on ToastHelper addition:

The ToastHelper class was introduced primarily to enable testing of Toast notifications in our app. Our code coverage metrics in SonarCloud showed that Toast-related code paths were previously uncovered by tests, and it also made my test coverage very low on this pr.

By extracting Toast logic into a dedicated helper class:
- We can now properly test Toast displays using mocks
- Previously uncovered Toast code paths are now testable
- Improves our overall test coverage metrics


### Issue Reference
Closes #278

