### PR TITLE
fix: Handle edge case of Horizons API responses

### DIFF
--- a/app/src/main/java/com/github/lookupgroup27/lookup/model/map/planets/PlanetsRepository.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/model/map/planets/PlanetsRepository.kt
@@ -6,7 +6,6 @@ import com.github.lookupgroup27.lookup.model.location.LocationProvider
 import com.github.lookupgroup27.lookup.model.map.renderables.Moon
 import com.github.lookupgroup27.lookup.model.map.renderables.Planet
 import com.github.lookupgroup27.lookup.util.CelestialObjectsUtils
-import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -209,7 +208,7 @@ class PlanetsRepository(
     // Make the network request to Horizons API
     val request = Request.Builder().url(url).build()
     client.newCall(request).execute().use { response ->
-      if (!response.isSuccessful) throw IOException("API call failed with code ${response.code}")
+      if (!response.isSuccessful) return null
 
       val json = JSONObject(response.body?.string() ?: return null)
       val result = json.optString("result", null) ?: return null
@@ -230,9 +229,15 @@ class PlanetsRepository(
 
       // According to Horizons format, RA and Dec are typically in columns 4 and 5 (0-based index: 3
       // and 4)
-      if (columns.size >= 3) {
+      if (columns.size > 4) {
         val raDeg = columns[3].toDoubleOrNull() ?: return null
         val decDeg = columns[4].toDoubleOrNull() ?: return null
+        return Pair(raDeg, decDeg)
+      } else if (columns.size ==
+          4) { // Sometimes Horizons changes format which gives a size 4 array where Ra and Dec
+        // are placed in the two last columns
+        val raDeg = columns[2].toDoubleOrNull() ?: return null
+        val decDeg = columns[3].toDoubleOrNull() ?: return null
         return Pair(raDeg, decDeg)
       }
 


### PR DESCRIPTION
This PR addresses the issue [#314](https://github.com/LookUpGroup27/LookUp/issues/314)

**Changes Made:**
- Fixed Retrieval of RA and DEC: Updated the logic for extracting RA (Right Ascension) and DEC (Declination) values from the JSON response to accommodate variations in the API's format.
- Improved Error Handling: Removed the exception throw when the response is unsuccessful to prevent app crashes during periods of slow or unstable internet connectivity.

**Impact:**
- Prevents crashes caused by unexpected JSON structure in Horizons API responses.
- Enhances app stability and user experience during network issues.
