### PR TITLE
 Disable Feed Access in Offline Mode

### DIFF
--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/feed/FeedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/feed/FeedScreenTest.kt
@@ -24,6 +24,7 @@ import com.github.lookupgroup27.lookup.ui.navigation.Screen
 import com.github.lookupgroup27.lookup.ui.navigation.TopLevelDestinations
 import com.github.lookupgroup27.lookup.ui.post.PostsViewModel
 import com.github.lookupgroup27.lookup.ui.profile.ProfileViewModel
+import com.github.lookupgroup27.lookup.util.NetworkUtils
 import com.google.firebase.auth.FirebaseAuth
 import io.mockk.every
 import io.mockk.mockkObject
@@ -57,6 +58,7 @@ class FeedScreenTest {
   private lateinit var locationProvider: LocationProvider
   private val user = FirebaseAuth.getInstance().currentUser // Get the current signed-in user
   private val userEmail = user?.email ?: ""
+    private val mockNavigationActions: NavigationActions = org.mockito.kotlin.mock()
 
   // Mock the logged-in user's profile
   val testUserProfile =
@@ -332,4 +334,20 @@ class FeedScreenTest {
     composeTestRule.onNodeWithText("Enable Location").assertExists() // Verify button text
     composeTestRule.onNodeWithTag("enable_location_button").performClick()
   }
+
+    @Test
+    fun testNavigationToFeedBlockedForOfflineMode() {
+        setFeedScreenContent(emptyList())
+        // Simulate offline mode
+        mockkObject(NetworkUtils)
+        every { NetworkUtils.isNetworkAvailable(any()) } returns false
+        // Simulate clicking the sky map tab in the bottom navigation
+        composeTestRule.onNodeWithTag("Feed").performClick()
+
+        // Wait for the UI to settle after the click
+        composeTestRule.waitForIdle()
+
+        // Verify that navigation to the Sky Map is never triggered
+        verify(mockNavigationActions, org.mockito.kotlin.never()).navigateTo(Screen.FEED)
+    }
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/feed/FeedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/feed/FeedScreenTest.kt
@@ -58,7 +58,7 @@ class FeedScreenTest {
   private lateinit var locationProvider: LocationProvider
   private val user = FirebaseAuth.getInstance().currentUser // Get the current signed-in user
   private val userEmail = user?.email ?: ""
-    private val mockNavigationActions: NavigationActions = org.mockito.kotlin.mock()
+  private val mockNavigationActions: NavigationActions = org.mockito.kotlin.mock()
 
   // Mock the logged-in user's profile
   val testUserProfile =
@@ -335,19 +335,19 @@ class FeedScreenTest {
     composeTestRule.onNodeWithTag("enable_location_button").performClick()
   }
 
-    @Test
-    fun testNavigationToFeedBlockedForOfflineMode() {
-        setFeedScreenContent(emptyList())
-        // Simulate offline mode
-        mockkObject(NetworkUtils)
-        every { NetworkUtils.isNetworkAvailable(any()) } returns false
-        // Simulate clicking the sky map tab in the bottom navigation
-        composeTestRule.onNodeWithTag("Feed").performClick()
+  @Test
+  fun testNavigationToFeedBlockedForOfflineMode() {
+    setFeedScreenContent(emptyList())
+    // Simulate offline mode
+    mockkObject(NetworkUtils)
+    every { NetworkUtils.isNetworkAvailable(any()) } returns false
+    // Simulate clicking the sky map tab in the bottom navigation
+    composeTestRule.onNodeWithTag("Feed").performClick()
 
-        // Wait for the UI to settle after the click
-        composeTestRule.waitForIdle()
+    // Wait for the UI to settle after the click
+    composeTestRule.waitForIdle()
 
-        // Verify that navigation to the Sky Map is never triggered
-        verify(mockNavigationActions, org.mockito.kotlin.never()).navigateTo(Screen.FEED)
-    }
+    // Verify that navigation to the Sky Map is never triggered
+    verify(mockNavigationActions, org.mockito.kotlin.never()).navigateTo(Screen.FEED)
+  }
 }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/BottomNavigationMenu.kt
@@ -65,7 +65,7 @@ fun BottomNavigationMenu(
                             context, "You need to log in to access the feed.", Toast.LENGTH_LONG)
                         .show()
                   }
-                  tab.route == Route.SKY_MAP && !isOnline.value -> {
+                    (tab.route ==  Route.FEED || tab.route == Route.SKY_MAP) && !isOnline.value -> {
                     toastHelper.showNoInternetToast()
                   }
                   selectedItem != tab.route -> {

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/navigation/BottomNavigationMenu.kt
@@ -65,7 +65,7 @@ fun BottomNavigationMenu(
                             context, "You need to log in to access the feed.", Toast.LENGTH_LONG)
                         .show()
                   }
-                    (tab.route ==  Route.FEED || tab.route == Route.SKY_MAP) && !isOnline.value -> {
+                  (tab.route == Route.FEED || tab.route == Route.SKY_MAP) && !isOnline.value -> {
                     toastHelper.showNoInternetToast()
                   }
                   selectedItem != tab.route -> {


### PR DESCRIPTION
## Changes
- Implemented blocking UI for feed tab in the bottom navigation bar when device is offline
- The toast message to inform users when feed access is blocked is also displayed for the feed
- Updated tests to cover offline mode behavior

## Why
You need to log in to access the feed, which is not possible to do offline anyway, so we originally did not plan on blocking the feed offline. However, users attempting to access the feed that were already logged in when offline mode was triggered could still access it, but it was empty. Because of that , and after some reflection, it was decided to block the feed also. This change provides clear feedback about offline status and prevents unnecessary API calls when they would fail anyway.

## Testing
- Verified feed is accessible in online mode
- Confirmed feed is blocked when device loses connection
- Tested Toast message appears correctly
