### PR TITLE
feat: lock app into portrait mode

### DIFF
--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/authentication/SignInKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/authentication/SignInKtTest.kt
@@ -6,8 +6,6 @@ import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.toPackage
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
 import com.github.lookupgroup27.lookup.ui.navigation.Screen
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
@@ -80,31 +78,6 @@ class SignInKtTest : TestCase() {
     verify(mockNavigationActions).navigateTo(Screen.MENU)
   }
 
-  /*@Test
-  fun testSignInScreenIsFullyVisibleInLandscape() {
-    // Set device orientation to landscape
-    setLandscapeOrientation()
-
-    // Launch the SignInScreen in landscape mode
-    composeTestRule.setContent { SignInScreen(mockNavigationActions) }
-
-    // Scroll to each component and verify it is displayed
-    composeTestRule.onNodeWithTag("loginTitle").performScrollTo().assertIsDisplayed()
-    composeTestRule.onNodeWithTag("loginTitle").assertTextEquals("Welcome to the Cosmos")
-    composeTestRule
-        .onNodeWithTag("loginButton")
-        .performScrollTo()
-        .assertIsDisplayed()
-        .assertHasClickAction()
-    composeTestRule
-        .onNodeWithTag("go_back_button_signin")
-        .assertIsDisplayed()
-        .assertHasClickAction()
-
-    // Reset orientation to portrait after the test
-    resetOrientation()
-  }*/
-
   @Test
   fun backArrowIsInTopLeftCorner() {
     composeTestRule.setContent { SignInScreen(mockNavigationActions) }
@@ -117,15 +90,5 @@ class SignInKtTest : TestCase() {
 
     assert(backArrowBounds.left < screenWidth * 0.1f)
     assert(backArrowBounds.top < screenHeight * 0.1f)
-  }
-
-  private fun setLandscapeOrientation() {
-    val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-    device.setOrientationLeft()
-  }
-
-  private fun resetOrientation() {
-    val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-    device.setOrientationNatural()
   }
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/authentication/SignInKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/authentication/SignInKtTest.kt
@@ -80,7 +80,7 @@ class SignInKtTest : TestCase() {
     verify(mockNavigationActions).navigateTo(Screen.MENU)
   }
 
-  @Test
+  /*@Test
   fun testSignInScreenIsFullyVisibleInLandscape() {
     // Set device orientation to landscape
     setLandscapeOrientation()
@@ -103,7 +103,7 @@ class SignInKtTest : TestCase() {
 
     // Reset orientation to portrait after the test
     resetOrientation()
-  }
+  }*/
 
   @Test
   fun backArrowIsInTopLeftCorner() {

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/LandingKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/overview/LandingKtTest.kt
@@ -10,8 +10,6 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.test.espresso.intent.Intents
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
 import com.github.lookupgroup27.lookup.ui.navigation.Screen
 import com.github.lookupgroup27.lookup.util.ToastHelper
@@ -99,31 +97,6 @@ class LandingKtTest {
   }
 
   @Test
-  fun testLandingScreenIsFullyVisibleInLandscape() {
-    // Set device orientation to landscape
-    setLandscapeOrientation()
-
-    // Launch LandingScreen in landscape mode
-    composeTestRule.setContent { LandingScreen(mockNavigationActions) }
-
-    // Ensure main UI elements are visible and accessible by scrolling if needed
-    composeTestRule.onNodeWithContentDescription("Look Up Logo").assertIsDisplayed()
-    composeTestRule
-        .onNodeWithContentDescription("Home Icon")
-        .performScrollTo()
-        .assertIsDisplayed()
-        .assertHasClickAction()
-    composeTestRule
-        .onNodeWithContentDescription("Background")
-        .assertIsDisplayed()
-        .assertHasClickAction()
-    composeTestRule.onNodeWithText("Click for full map view").assertIsDisplayed()
-
-    // Reset orientation to portrait after the test
-    resetOrientation()
-  }
-
-  @Test
   fun testBackgroundClickDoesNotNavigateToMapWhenOffline() {
     // Simulate offline mode
     simulateOnlineMode(false)
@@ -165,15 +138,5 @@ class LandingKtTest {
 
     // Verify no navigation occurred
     verify(mockNavigationActions, never()).navigateTo(Screen.SKY_MAP)
-  }
-
-  private fun setLandscapeOrientation() {
-    val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-    device.setOrientationLeft()
-  }
-
-  private fun resetOrientation() {
-    val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-    device.setOrientationNatural()
   }
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/profile/ProfileKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/profile/ProfileKtTest.kt
@@ -4,10 +4,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import com.github.lookupgroup27.lookup.R
 import com.github.lookupgroup27.lookup.model.profile.ProfileRepository
 import com.github.lookupgroup27.lookup.ui.navigation.LIST_TOP_LEVEL_DESTINATION
@@ -181,43 +178,5 @@ class ProfileKtTest {
 
     // Verify that no further interactions (including `navigateTo()`) occurred
     Mockito.verifyNoMoreInteractions(mockNavigationActions)
-  }
-
-  @Test
-  fun testProfileScreenIsScrollableAndFullyVisibleInLandscape() {
-    // Set the device to landscape orientation
-    setLandscapeOrientation()
-
-    // Launch the ProfileScreen in landscape mode
-    composeTestRule.setContent {
-      ProfileScreen(
-          navigationActions = mockNavigationActions, avatarViewModel = mockAvatarViewModel)
-    }
-
-    // Check that main elements are displayed after scrolling in landscape mode
-    composeTestRule
-        .onNodeWithContentDescription(getResourceString(R.string.profile_profile_icon_description))
-        .assertExists()
-    composeTestRule
-        .onNodeWithText(getResourceString(R.string.profile_personal_info_button))
-        .performScrollTo()
-        .assertExists()
-    composeTestRule
-        .onNodeWithText(getResourceString(R.string.profile_collection_button))
-        .performScrollTo()
-        .assertExists()
-
-    // Reset orientation to portrait after the test
-    resetOrientation()
-  }
-
-  private fun setLandscapeOrientation() {
-    val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-    device.setOrientationLeft()
-  }
-
-  private fun resetOrientation() {
-    val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-    device.setOrientationNatural()
   }
 }

--- a/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/quiz/QuizKtTest.kt
+++ b/app/src/androidTest/java/com/github/lookupgroup27/lookup/ui/quiz/QuizKtTest.kt
@@ -8,8 +8,6 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import com.github.lookupgroup27.lookup.model.quiz.QuizRepository
 import com.github.lookupgroup27.lookup.ui.navigation.NavigationActions
 import com.github.lookupgroup27.lookup.ui.navigation.Screen
@@ -142,40 +140,5 @@ class QuizKtTest {
 
     // Verify no navigation actions are triggered
     verifyNoInteractions(mockNavigationActions)
-  }
-
-  @Test
-  fun quizScreen_displaysBottomElementsInLandscapeModeWithScroll() {
-    // Set device orientation to landscape
-    setLandscapeOrientation()
-
-    // Load the QuizScreen in landscape orientation
-    composeTestRule.setContent {
-      QuizScreen(quizViewModel, navigationActions = mockNavigationActions)
-    }
-
-    // In landscape mode, verify top elements are displayed
-    composeTestRule.onNodeWithTag("quiz_screen").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("go_back_button_quiz").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("background_test_tag").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("quiz_title").assertIsDisplayed()
-    composeTestRule.onNodeWithText("Take a Quiz").assertIsDisplayed()
-
-    // Scroll to and verify the visibility of bottom elements in the quiz screen
-    composeTestRule.onNodeWithTag("solar system_button").performScrollTo().assertIsDisplayed()
-    composeTestRule.onNodeWithTag("earth_button").performScrollTo().assertIsDisplayed()
-
-    // Reset orientation to portrait after test
-    resetOrientation()
-  }
-
-  private fun setLandscapeOrientation() {
-    val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-    device.setOrientationLeft()
-  }
-
-  private fun resetOrientation() {
-    val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-    device.setOrientationNatural()
   }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
 
         <activity
             android:name=".MainActivity"
+            android:screenOrientation="portrait"
             android:exported="true"
             android:label="@string/title_activity_main"
             android:theme="@style/Theme.LookUpApp">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,6 @@
 
         <activity
             android:name=".MainActivity"
-            android:screenOrientation="portrait"
             android:exported="true"
             android:label="@string/title_activity_main"
             android:theme="@style/Theme.LookUpApp">

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/authentication/SignIn.kt
@@ -1,9 +1,11 @@
 package com.github.lookupgroup27.lookup.ui.authentication
 
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.util.Log
 import android.widget.Toast
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
@@ -56,6 +58,12 @@ import kotlinx.coroutines.tasks.await
 @Composable
 fun SignInScreen(navigationActions: NavigationActions) {
   val context = LocalContext.current
+
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
 
   val launcher =
       rememberFirebaseAuthLauncher(

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/authentication/SignIn.kt
@@ -59,11 +59,11 @@ import kotlinx.coroutines.tasks.await
 fun SignInScreen(navigationActions: NavigationActions) {
   val context = LocalContext.current
 
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   val launcher =
       rememberFirebaseAuthLauncher(

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/calendar/Calendar.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/calendar/Calendar.kt
@@ -50,13 +50,13 @@ fun CalendarScreen(
     calendarViewModel: CalendarViewModel = viewModel(),
     navigationActions: NavigationActions
 ) {
-    val context = LocalContext.current
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  val context = LocalContext.current
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   // State variables for selected date, search query, and visibility of the search dialog.
   var selectedDate by remember { mutableStateOf(Date()) }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/calendar/Calendar.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/calendar/Calendar.kt
@@ -1,5 +1,7 @@
 package com.github.lookupgroup27.lookup.ui.calendar
 
+import android.content.pm.ActivityInfo
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.*
@@ -9,6 +11,7 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.*
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -47,6 +50,14 @@ fun CalendarScreen(
     calendarViewModel: CalendarViewModel = viewModel(),
     navigationActions: NavigationActions
 ) {
+    val context = LocalContext.current
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
+
   // State variables for selected date, search query, and visibility of the search dialog.
   var selectedDate by remember { mutableStateOf(Date()) }
   var searchQuery by remember { mutableStateOf("") }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/feed/Feed.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/feed/Feed.kt
@@ -2,9 +2,11 @@ package com.github.lookupgroup27.lookup.ui.feed
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import android.util.Log
 import android.widget.Toast
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
@@ -65,6 +67,14 @@ fun FeedScreen(
     initialNearbyPosts: List<Post>? = null,
     testNoLoca: Boolean = false
 ) {
+    val context = LocalContext.current
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
+
   // Fetch user profile
   LaunchedEffect(Unit) {
     Log.d("FeedScreen", "Fetching user profile")
@@ -81,7 +91,6 @@ fun FeedScreen(
   val email by remember { mutableStateOf(userEmail) }
 
   // Location setup
-  val context = LocalContext.current
   val locationProvider = LocationProviderSingleton.getInstance(context)
   var locationPermissionGranted by remember {
     mutableStateOf(

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/feed/Feed.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/feed/Feed.kt
@@ -67,13 +67,13 @@ fun FeedScreen(
     initialNearbyPosts: List<Post>? = null,
     testNoLoca: Boolean = false
 ) {
-    val context = LocalContext.current
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  val context = LocalContext.current
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   // Fetch user profile
   LaunchedEffect(Unit) {

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/fullscreen/FullScreen.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/fullscreen/FullScreen.kt
@@ -47,12 +47,12 @@ fun FullScreenImageScreen(
 ) {
   val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   // State to track if a toast for empty imageUrl has been shown
   var hasShownEmptyToast by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/fullscreen/FullScreen.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/fullscreen/FullScreen.kt
@@ -1,6 +1,8 @@
 package com.github.lookupgroup27.lookup.ui.fullscreen
 
+import android.content.pm.ActivityInfo
 import android.widget.Toast
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -44,6 +46,13 @@ fun FullScreenImageScreen(
     description: String
 ) {
   val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
 
   // State to track if a toast for empty imageUrl has been shown
   var hasShownEmptyToast by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/GoogleMap.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/GoogleMap.kt
@@ -60,12 +60,12 @@ fun GoogleMapScreen(
 ) {
   val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   val locationProvider = LocationProviderSingleton.getInstance(context)
   var hasLocationPermission by remember {

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/GoogleMap.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/googlemap/GoogleMap.kt
@@ -2,8 +2,10 @@ package com.github.lookupgroup27.lookup.ui.googlemap
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import android.widget.Toast
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
@@ -57,6 +59,14 @@ fun GoogleMapScreen(
     testNoLoca: Boolean = false
 ) {
   val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
+
   val locationProvider = LocationProviderSingleton.getInstance(context)
   var hasLocationPermission by remember {
     mutableStateOf(

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/EditImage.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/EditImage.kt
@@ -78,12 +78,12 @@ fun EditImageScreen(
   val editImageState by editImageViewModel.editImageState.collectAsState()
   val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   var description by remember { mutableStateOf(postDescription) }
   var isEditing by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/EditImage.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/EditImage.kt
@@ -1,6 +1,8 @@
 package com.github.lookupgroup27.lookup.ui.image
 
+import android.content.pm.ActivityInfo
 import android.widget.Toast
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -15,6 +17,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -74,6 +77,13 @@ fun EditImageScreen(
 ) {
   val editImageState by editImageViewModel.editImageState.collectAsState()
   val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
 
   var description by remember { mutableStateOf(postDescription) }
   var isEditing by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImageReview.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImageReview.kt
@@ -1,6 +1,8 @@
 package com.github.lookupgroup27.lookup.ui.image
 
+import android.content.pm.ActivityInfo
 import android.widget.Toast
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -12,6 +14,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -61,6 +64,14 @@ fun ImageReviewScreen(
     timestamp: Long?
 ) {
   val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
+
   val locationProvider = LocationProviderSingleton.getInstance(context)
   val currentTimestamp = timestamp ?: System.currentTimeMillis() // Fallback to current time
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImageReview.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/ImageReview.kt
@@ -65,12 +65,12 @@ fun ImageReviewScreen(
 ) {
   val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   val locationProvider = LocationProviderSingleton.getInstance(context)
   val currentTimestamp = timestamp ?: System.currentTimeMillis() // Fallback to current time

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/TakeImage.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/TakeImage.kt
@@ -55,12 +55,12 @@ fun CameraCapture(
 ) {
   val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   var imageCapture: ImageCapture? by remember { mutableStateOf(null) }
   var isCameraPermissionGranted by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/TakeImage.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/image/TakeImage.kt
@@ -1,9 +1,11 @@
 package com.github.lookupgroup27.lookup.ui.image
 
 import android.Manifest
+import android.content.pm.ActivityInfo
 import android.net.Uri
 import android.os.Environment
 import android.widget.Toast
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.CameraSelector
@@ -52,6 +54,14 @@ fun CameraCapture(
     navigationActions: NavigationActions,
 ) {
   val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
+
   var imageCapture: ImageCapture? by remember { mutableStateOf(null) }
   var isCameraPermissionGranted by remember { mutableStateOf(false) }
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/login/Login.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/login/Login.kt
@@ -1,9 +1,12 @@
 package com.github.lookupgroup27.lookup.ui.login
 
+import android.content.pm.ActivityInfo
 import android.widget.Toast
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -27,6 +30,14 @@ import com.github.lookupgroup27.lookup.ui.register.components.CustomOutlinedText
 @Composable
 fun LoginScreen(viewModel: LoginViewModel, navigationActions: NavigationActions) {
   val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
+
   val uiState by viewModel.uiState.collectAsState()
 
   AuthScreen(

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/login/Login.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/login/Login.kt
@@ -31,12 +31,12 @@ import com.github.lookupgroup27.lookup.ui.register.components.CustomOutlinedText
 fun LoginScreen(viewModel: LoginViewModel, navigationActions: NavigationActions) {
   val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   val uiState by viewModel.uiState.collectAsState()
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/map/Map.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/map/Map.kt
@@ -61,6 +61,14 @@ private const val LOCATION_PERMISSION_REQUEST_CODE: Int = 1001
 fun MapScreen(navigationActions: NavigationActions, mapViewModel: MapViewModel) {
 
   val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
+
   val user = FirebaseAuth.getInstance().currentUser
   val isUserLoggedIn = user != null
   val activity =

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/map/Map.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/map/Map.kt
@@ -62,12 +62,12 @@ fun MapScreen(navigationActions: NavigationActions, mapViewModel: MapViewModel) 
 
   val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   val user = FirebaseAuth.getInstance().currentUser
   val isUserLoggedIn = user != null

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Landing.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Landing.kt
@@ -46,12 +46,12 @@ fun LandingScreen(
 
   val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Landing.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Landing.kt
@@ -1,6 +1,8 @@
 package com.github.lookupgroup27.lookup.ui.overview
 
 import android.annotation.SuppressLint
+import android.content.pm.ActivityInfo
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -12,6 +14,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -42,6 +45,14 @@ fun LandingScreen(
 ) {
 
   val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
+
   val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
 
   // Background container with clickable modifier to navigate to Map screen

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Menu.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Menu.kt
@@ -1,6 +1,8 @@
 package com.github.lookupgroup27.lookup.ui.overview
 
 import android.annotation.SuppressLint
+import android.content.pm.ActivityInfo
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -39,6 +41,14 @@ fun MenuScreen(
   val userId = auth.currentUser?.uid.orEmpty()
 
   val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
+
   val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
 
   // Fetch the selected avatar for the logged-in user

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Menu.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/overview/Menu.kt
@@ -42,12 +42,12 @@ fun MenuScreen(
 
   val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   val isOnline = remember { mutableStateOf(NetworkUtils.isNetworkAvailable(context)) }
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordReset.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordReset.kt
@@ -42,14 +42,14 @@ import com.github.lookupgroup27.lookup.ui.navigation.Screen
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PasswordResetScreen(viewModel: PasswordResetViewModel, navigationActions: NavigationActions) {
-    val context = LocalContext.current
+  val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   // Observes the UI state from the ViewModel
   val uiState by viewModel.uiState.collectAsState()

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordReset.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/passwordreset/PasswordReset.kt
@@ -1,5 +1,7 @@
 package com.github.lookupgroup27.lookup.ui.passwordreset
 
+import android.content.pm.ActivityInfo
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -9,12 +11,14 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -38,6 +42,15 @@ import com.github.lookupgroup27.lookup.ui.navigation.Screen
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PasswordResetScreen(viewModel: PasswordResetViewModel, navigationActions: NavigationActions) {
+    val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
+
   // Observes the UI state from the ViewModel
   val uiState by viewModel.uiState.collectAsState()
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/planetselection/PlanetSelectionScreen.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/planetselection/PlanetSelectionScreen.kt
@@ -42,14 +42,14 @@ fun PlanetSelectionScreen(
     viewModel: PlanetSelectionViewModel = viewModel(),
     navigationActions: NavigationActions
 ) {
-    val context = LocalContext.current
+  val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   val planets = viewModel.planets
   val selectedPlanet by viewModel.selectedPlanet.collectAsState()

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/planetselection/PlanetSelectionScreen.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/planetselection/PlanetSelectionScreen.kt
@@ -1,6 +1,8 @@
 package com.github.lookupgroup27.lookup.ui.planetselection
 
 import android.annotation.SuppressLint
+import android.content.pm.ActivityInfo
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
@@ -14,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Color.Companion.White
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -39,6 +42,15 @@ fun PlanetSelectionScreen(
     viewModel: PlanetSelectionViewModel = viewModel(),
     navigationActions: NavigationActions
 ) {
+    val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
+
   val planets = viewModel.planets
   val selectedPlanet by viewModel.selectedPlanet.collectAsState()
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/Collection.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/Collection.kt
@@ -48,14 +48,14 @@ fun CollectionScreen(
     viewModel: CollectionViewModel =
         androidx.lifecycle.viewmodel.compose.viewModel(factory = CollectionViewModel.Factory)
 ) {
-    val context = LocalContext.current
+  val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   val myPosts by viewModel.myPosts.collectAsState()
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/Collection.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/Collection.kt
@@ -1,5 +1,7 @@
 package com.github.lookupgroup27.lookup.ui.profile
 
+import android.content.pm.ActivityInfo
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -15,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -45,6 +48,15 @@ fun CollectionScreen(
     viewModel: CollectionViewModel =
         androidx.lifecycle.viewmodel.compose.viewModel(factory = CollectionViewModel.Factory)
 ) {
+    val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
+
   val myPosts by viewModel.myPosts.collectAsState()
 
   Box(

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/Profile.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/Profile.kt
@@ -35,14 +35,14 @@ import components.BackgroundImage
 
 @Composable
 fun ProfileScreen(navigationActions: NavigationActions, avatarViewModel: AvatarViewModel) {
-    val context = LocalContext.current
+  val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   val configuration = LocalConfiguration.current
   val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/Profile.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/Profile.kt
@@ -1,6 +1,8 @@
 package com.github.lookupgroup27.lookup.ui.profile
 
+import android.content.pm.ActivityInfo
 import android.content.res.Configuration
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -12,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -32,6 +35,15 @@ import components.BackgroundImage
 
 @Composable
 fun ProfileScreen(navigationActions: NavigationActions, avatarViewModel: AvatarViewModel) {
+    val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
+
   val configuration = LocalConfiguration.current
   val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
   val user = FirebaseAuth.getInstance().currentUser

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/ProfileInformation.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/ProfileInformation.kt
@@ -26,14 +26,14 @@ fun ProfileInformationScreen(
     navigationActions: NavigationActions
 ) {
 
-    val context = LocalContext.current
+  val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   val scrollState = rememberScrollState()
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/ProfileInformation.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/profile/ProfileInformation.kt
@@ -1,6 +1,8 @@
 package com.github.lookupgroup27.lookup.ui.profile
 
 import android.annotation.SuppressLint
+import android.content.pm.ActivityInfo
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -10,6 +12,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.*
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.github.lookupgroup27.lookup.model.profile.*
@@ -22,6 +25,15 @@ fun ProfileInformationScreen(
     profileViewModel: ProfileViewModel,
     navigationActions: NavigationActions
 ) {
+
+    val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
 
   val scrollState = rememberScrollState()
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/quiz/Quiz.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/quiz/Quiz.kt
@@ -1,6 +1,8 @@
 package com.github.lookupgroup27.lookup.ui.quiz
 
 import android.annotation.SuppressLint
+import android.content.pm.ActivityInfo
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -11,6 +13,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -39,6 +42,15 @@ import components.BackgroundImage
 fun QuizScreen(viewModel: QuizViewModel, navigationActions: NavigationActions) {
 
   val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
+
+
   val bestScores = viewModel.getAllBestScores()
 
   BoxWithConstraints(modifier = Modifier.fillMaxSize().testTag("quiz_screen")) {

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/quiz/Quiz.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/quiz/Quiz.kt
@@ -43,13 +43,12 @@ fun QuizScreen(viewModel: QuizViewModel, navigationActions: NavigationActions) {
 
   val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
-
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   val bestScores = viewModel.getAllBestScores()
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/quiz/QuizPlay.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/quiz/QuizPlay.kt
@@ -43,14 +43,14 @@ import com.github.lookupgroup27.lookup.ui.theme.DarkPurple
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 fun QuizPlayScreen(viewModel: QuizViewModel, navigationActions: NavigationActions) {
-    val context = LocalContext.current
+  val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   val quizQuestions by viewModel.quizQuestions.collectAsState()
   val currentQuestionIndex by viewModel.currentQuestionIndex.collectAsState()

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/quiz/QuizPlay.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/quiz/QuizPlay.kt
@@ -1,6 +1,8 @@
 package com.github.lookupgroup27.lookup.ui.quiz
 
 import android.annotation.SuppressLint
+import android.content.pm.ActivityInfo
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -8,6 +10,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -16,6 +19,7 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -39,6 +43,15 @@ import com.github.lookupgroup27.lookup.ui.theme.DarkPurple
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 fun QuizPlayScreen(viewModel: QuizViewModel, navigationActions: NavigationActions) {
+    val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
+
   val quizQuestions by viewModel.quizQuestions.collectAsState()
   val currentQuestionIndex by viewModel.currentQuestionIndex.collectAsState()
   val score by viewModel.score.collectAsState()

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/register/Register.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/register/Register.kt
@@ -1,6 +1,5 @@
 package com.github.lookupgroup27.lookup.ui.register
 
-import android.annotation.SuppressLint
 import android.content.pm.ActivityInfo
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -38,12 +37,12 @@ fun RegisterScreen(
 ) {
   val context = LocalContext.current
 
-    // Lock the screen orientation to portrait mode.
-    DisposableEffect(Unit) {
-        val activity = context as? ComponentActivity
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
-    }
+  // Lock the screen orientation to portrait mode.
+  DisposableEffect(Unit) {
+    val activity = context as? ComponentActivity
+    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+  }
 
   val uiState by viewModel.uiState.collectAsState()
 

--- a/app/src/main/java/com/github/lookupgroup27/lookup/ui/register/Register.kt
+++ b/app/src/main/java/com/github/lookupgroup27/lookup/ui/register/Register.kt
@@ -1,6 +1,9 @@
 package com.github.lookupgroup27.lookup.ui.register
 
+import android.annotation.SuppressLint
+import android.content.pm.ActivityInfo
 import android.widget.Toast
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
@@ -34,6 +37,14 @@ fun RegisterScreen(
     viewModel: RegisterViewModel = viewModel(factory = RegisterViewModel.Factory)
 ) {
   val context = LocalContext.current
+
+    // Lock the screen orientation to portrait mode.
+    DisposableEffect(Unit) {
+        val activity = context as? ComponentActivity
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+    }
+
   val uiState by viewModel.uiState.collectAsState()
 
   Box(modifier = Modifier.fillMaxSize()) {


### PR DESCRIPTION
This PR deals with issue #313 

**Description:**

This pull request addresses the need to lock the app in portrait mode for improved user experience and to ensure consistent behavior across all screens. By restricting the orientation to portrait mode, the app avoids unintended UI issues caused by rotation.

**Changes Made:**

Updated the AndroidManifest.xml to set screenOrientation to portrait for all activities.
Ensured the app maintains a consistent layout regardless of device rotation.
Tested the implementation to confirm the app behavior remains stable in portrait mode.

**Key Benefits:**

Prevents UI glitches caused by screen rotations.
Enhances usability, especially for layouts optimized for portrait mode.
Provides a smoother and more predictable user experience.
